### PR TITLE
Fix NullPointerException in Linux during startup.

### DIFF
--- a/src/main/resources/playonlinux.properties
+++ b/src/main/resources/playonlinux.properties
@@ -31,3 +31,5 @@ application.macosx.tools                    =
 application.environment.path                =
 application.environment.ld                  =
 application.environment.dyld                =
+
+webservice.url                              =           http://phoenicis.playonlinux.com/index.php/categories


### PR DESCRIPTION
The missing property-key "webservice.url" causes a `NullPointerException` for me on Linux (since an empty `rawProperty` is passed to `pattern.matcher()`). Since this key is present in the `playonmac.properties` file, I figured this would be a suitable fix.