### PR TITLE
Added magic comment for encoding in python scripts.

### DIFF
--- a/src/main/python/SetupWindow/SetupWindowManager.py
+++ b/src/main/python/SetupWindow/SetupWindowManager.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # Copyright (C) 2015 Pâris Quentin
 

--- a/src/main/python/SetupWindow/SetupWindowNetcatCommandParser.py
+++ b/src/main/python/SetupWindow/SetupWindowNetcatCommandParser.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# coding=utf-8
+
 # Copyright (C) 2015 Pâris Quentin
 
 # This program is free software; you can redistribute it and/or modify

--- a/src/main/python/SetupWindow/SetupWindowNetcatServer.py
+++ b/src/main/python/SetupWindow/SetupWindowNetcatServer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # Copyright (C) 2015 Pâris Quentin
 

--- a/src/main/python/v4wrapper.py
+++ b/src/main/python/v4wrapper.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 # Copyright (C) 2015 Pâris Quentin
 


### PR DESCRIPTION
Using the `Tools\Running a local Script` function, I am constantly getting ErrorMessages like:
```
Exception in thread "Thread-7" SyntaxError: Non-ASCII character in file '/mnt/coding/Java/PlayOnLinux/POL-POM-5/src/main/python/v4wrapper.py', but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```

This is a possible fix for that. But I am not too familiar with python, so that might be the wrong approach.