### PR TITLE
Implemented TestCase for the LegacyScript-Wrapper.

### DIFF
--- a/src/main/java/com/playonlinux/domain/Script.java
+++ b/src/main/java/com/playonlinux/domain/Script.java
@@ -75,10 +75,7 @@ public abstract class Script implements BackgroundService {
             @Override
             public void run() {
                 try {
-                    File pythonPath = new File("src/main/python");
-                    System.getProperties().setProperty("python.path", pythonPath.getAbsolutePath());
-                    PythonInterpreter pythonInterpreter = new PythonInterpreter();
-                    executeScript(pythonInterpreter);
+                    runScript();
                 } catch (PyException e) {
                     if (e.getCause() instanceof CancelException || e.getCause() instanceof InterruptedException) {
                         System.out.println("The script was canceled! "); // Fixme: better logging system
@@ -94,6 +91,13 @@ public abstract class Script implements BackgroundService {
         };
         scriptThread.start();
 
+    }
+
+    public void runScript() {
+        File pythonPath = new File("src/main/python");
+        System.getProperties().setProperty("python.path", pythonPath.getAbsolutePath());
+        PythonInterpreter pythonInterpreter = new PythonInterpreter();
+        executeScript(pythonInterpreter);
     }
 
     protected abstract void executeScript(PythonInterpreter pythonInterpreter);

--- a/src/test/java/com/playonlinux/domain/LegacyWrapperTest.java
+++ b/src/test/java/com/playonlinux/domain/LegacyWrapperTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.domain;
+
+import org.junit.Test;
+import org.python.util.PythonInterpreter;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+public class LegacyWrapperTest {
+
+    @Test
+    public void testLegacyWrapper() throws Exception {
+        File tmpFile = new File("/tmp/POL_WrapperTest");
+        //ensure temporary file does not exist before running the testScript
+        if(tmpFile.exists()){
+            tmpFile.delete();
+        }
+        File testScript = new File(this.getClass().getResource("wrapperTestScript.sh").getPath());
+        Script testScriptWrapper = Script.createInstance(testScript);
+        //Fixme: This is rather ugly here. Create a static Helper for PythonInterpreters?
+        File pythonPath = new File("src/main/python");
+        System.getProperties().setProperty("python.path", pythonPath.getAbsolutePath());
+        testScriptWrapper.executeScript(new PythonInterpreter());
+        //file should exist now
+        assertTrue(tmpFile.exists());
+    }
+
+}

--- a/src/test/java/com/playonlinux/domain/LegacyWrapperTest.java
+++ b/src/test/java/com/playonlinux/domain/LegacyWrapperTest.java
@@ -36,10 +36,7 @@ public class LegacyWrapperTest {
         }
         File testScript = new File(this.getClass().getResource("wrapperTestScript.sh").getPath());
         Script testScriptWrapper = Script.createInstance(testScript);
-        //Fixme: This is rather ugly here. Create a static Helper for PythonInterpreters?
-        File pythonPath = new File("src/main/python");
-        System.getProperties().setProperty("python.path", pythonPath.getAbsolutePath());
-        testScriptWrapper.executeScript(new PythonInterpreter());
+        testScriptWrapper.runScript();
         //file should exist now
         assertTrue(tmpFile.exists());
     }

--- a/src/test/resources/com/playonlinux/domain/wrapperTestScript.sh
+++ b/src/test/resources/com/playonlinux/domain/wrapperTestScript.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+[ "$PLAYONLINUX" = "" ] && exit 0
+source "$PLAYONLINUX/lib/sources"
+
+TITLE="Legacy script"
+
+touch /tmp/POL_WrapperTest
+
+exit


### PR DESCRIPTION
I now implemented a TestCase which is running a LegacyScript creating a temporary file and checking if that file exists afterwards. The way I used the PythonInterpreter here is somewhat ugly. Maybe we should create a static HelperClass for instantiating and setting up PythonInterpreters?