### PR TITLE
Fix small Typo resolving FileNotFound issue.

### DIFF
--- a/src/main/bash/lib/sources
+++ b/src/main/bash/lib/sources
@@ -24,7 +24,7 @@ fi
 
 if [ -z "$PLAYONLINUX_BASH_INCLUDED" ]; then
 	source "$PLAYONLINUX/lib/setupWindow"
-	source "$PLAyONLINUX/lib/scripts"
+	source "$PLAYONLINUX/lib/scripts"
 
 	export PLAYONLINUX_BASH_INCLUDED="TRUE"
 fi


### PR DESCRIPTION
Fixed small typo which caused that the `bash/lib/scripts` - script could not be found.