### PR TITLE
Revert "Rewrote InstallWindow's mainScene with automatic sizing."

### DIFF
--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
@@ -24,13 +24,14 @@ import com.playonlinux.ui.api.RemoteAvailableInstallers;
 import com.playonlinux.ui.impl.javafx.common.HtmlTemplate;
 import com.playonlinux.ui.impl.javafx.common.PlayOnLinuxScene;
 import javafx.application.Platform;
-import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.*;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.TextAlignment;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
@@ -97,14 +98,15 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
     }
 
     private void setUpMainScene() {
-        BorderPane mainPane = new BorderPane();
+        // TODO: Improve this scene (get rid of absolute positioning, ...)
+
+        Pane mainPane = new Pane();
         mainScene = new PlayOnLinuxScene(mainPane, 800, 545);
 
-        VBox centerPane = new VBox();
-        centerPane.setSpacing(10);
-        centerPane.setPadding(new Insets(10, 10, 0, 10));
         searchWidget = new TextField();
-        searchWidget.setMaxWidth(250);
+        searchWidget.setLayoutY(77);
+        searchWidget.setLayoutX(10);
+        searchWidget.setPrefWidth(250);
         searchWidget.setPromptText(translate("Search"));
 
         try {
@@ -116,33 +118,33 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
             alert.show();
             e.printStackTrace();
         }
-        centerPane.getChildren().addAll(searchWidget, availableInstallerListWidget);
-        VBox.setVgrow(availableInstallerListWidget, Priority.ALWAYS);
+
+        availableInstallerListWidget.setLayoutY(112);
+        availableInstallerListWidget.setLayoutX(10);
+        availableInstallerListWidget.setPrefWidth(550);
+        availableInstallerListWidget.setPrefHeight(385);
 
         descriptionWidget = new WebView();
-        descriptionWidget.setPrefWidth(230);
-
-        HBox bottomPane = new HBox();
-        bottomPane.setSpacing(10);
-        bottomPane.setPadding(new Insets(5));
-        bottomPane.setAlignment(Pos.CENTER_RIGHT);
+        descriptionWidget.setLayoutX(570);
+        descriptionWidget.setLayoutY(112);
+        descriptionWidget.setPrefWidth(218);
+        descriptionWidget.setPrefHeight(200);
 
         ImageView installImage = new ImageView(new Image(getClass().getResourceAsStream("install.png")));
         installImage.setFitWidth(16);
         installImage.setFitHeight(16);
         installButton = new Button(translate("Install"), installImage);
+        installButton.setLayoutY(510);
         installButton.setDisable(true);
 
         ImageView updateImage = new ImageView(new Image(getClass().getResourceAsStream("refresh.png")));
         updateImage.setFitWidth(16);
         updateImage.setFitHeight(16);
         refreshButton = new Button(translate("Refresh"), updateImage);
-        bottomPane.getChildren().addAll(installButton, refreshButton);
+        refreshButton.setLayoutY(510);
 
-        mainPane.setTop(header);
-        mainPane.setCenter(centerPane);
-        mainPane.setRight(descriptionWidget);
-        mainPane.setBottom(bottomPane);
+        mainPane.getChildren().addAll(header, availableInstallerListWidget, searchWidget,
+                descriptionWidget, installButton, refreshButton);
 
     }
 
@@ -192,9 +194,7 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
         this.setScene(updateScene);
     }
 
-    private void showFailureScene() {
-        this.setScene(failureScene);
-    }
+    private void showFailureScene() { this.setScene(failureScene); }
 
 
     private void setUpEvents() throws PlayOnLinuxError {


### PR DESCRIPTION
I'm reverting it because I haven't seen that there is a small thing to fix. The GUI will actually have also a miniature. So we cannot really dock the Webkit widget to the right.

Here is the same window for PlayOnLinux v4 
![screen shot 2015-05-22 at 00 40 37](https://cloud.githubusercontent.com/assets/373645/7761233/390ade7c-001b-11e5-8634-257241cc6290.png)

Reverts PlayOnLinux/POL-POM-5#19