### PR TITLE
Refactor the Filtering of Installers

### DIFF
--- a/src/main/java/com/playonlinux/services/RemoteAvailableInstallersPlayOnLinuxImplementation.java
+++ b/src/main/java/com/playonlinux/services/RemoteAvailableInstallersPlayOnLinuxImplementation.java
@@ -65,7 +65,7 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
         downloadEnvelopeDto = (DownloadEnvelopeDTO<AvailableCategoriesDTO>) arg;
 
         try {
-            if(downloadEnvelopeDto.getEnvelopeContent() != null) {
+            if (downloadEnvelopeDto.getEnvelopeContent() != null) {
                 List<CategoryDTO> availableCategories = new ArrayList<>(
                         downloadEnvelopeDto.getEnvelopeContent().getCategories()
                 );
@@ -98,8 +98,8 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
     @Override
     public Iterable<ScriptDTO> getAllScripts() {
         List<ScriptDTO> scripts = new ArrayList<>();
-        for(CategoryDTO categoryDTO: new ArrayList<>(categoriesDTO)) {
-            for(ScriptDTO scriptDTO: new ArrayList<>(categoryDTO.getScripts())) {
+        for (CategoryDTO categoryDTO : new ArrayList<>(categoriesDTO)) {
+            for (ScriptDTO scriptDTO : new ArrayList<>(categoryDTO.getScripts())) {
                 scripts.add(scriptDTO);
             }
         }
@@ -128,14 +128,14 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
     public Iterable<ScriptDTO> getAllScripts(InstallerFilter filter) throws PlayOnLinuxError {
         Iterable<ScriptDTO> scriptsToFilter;
         List<ScriptDTO> scripts = new ArrayList<>();
-        if(filter.getCategory() == null){
+        if (filter.getCategory() == null) {
             scriptsToFilter = this.getAllScripts();
-        }else{
+        } else {
             scriptsToFilter = this.getAllScriptsInCategory(filter.getCategory());
         }
 
-        for(ScriptDTO script : scriptsToFilter){
-            if(filter.apply(script)){
+        for (ScriptDTO script : scriptsToFilter) {
+            if (filter.apply(script)) {
                 scripts.add(script);
             }
         }
@@ -144,8 +144,8 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
 
     @Override
     public ScriptDTO getScriptByName(String scriptName) throws PlayOnLinuxError {
-        for(ScriptDTO scriptDTO: this.getAllScripts()) {
-            if(scriptName.equals(scriptDTO.getName())) {
+        for (ScriptDTO scriptDTO : this.getAllScripts()) {
+            if (scriptName.equals(scriptDTO.getName())) {
                 return scriptDTO;
             }
         }
@@ -155,7 +155,7 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
 
     @Override
     public void refresh() {
-        if(remoteAvailableInstallers != null) {
+        if (remoteAvailableInstallers != null) {
             remoteAvailableInstallers.deleteObserver(this);
             playOnLinuxBackgroundServicesManager.unregister(remoteAvailableInstallers);
         }
@@ -165,8 +165,8 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
     }
 
     private Iterable<ScriptDTO> getAllScriptsInCategory(String categoryName) throws PlayOnLinuxError {
-        for(CategoryDTO categoryDTO: categoriesDTO) {
-            if(categoryName.equals(categoryDTO.getName())) {
+        for (CategoryDTO categoryDTO : categoriesDTO) {
+            if (categoryName.equals(categoryDTO.getName())) {
                 return getAllScriptsInCategory(categoryDTO);
             }
         }
@@ -175,7 +175,7 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
 
     private Iterable<ScriptDTO> getAllScriptsInCategory(CategoryDTO categoryDTO) {
         List<ScriptDTO> scripts = new ArrayList<>();
-        for(ScriptDTO scriptDTO: new ArrayList<>(categoryDTO.getScripts())) {
+        for (ScriptDTO scriptDTO : new ArrayList<>(categoryDTO.getScripts())) {
             scripts.add(scriptDTO);
         }
 

--- a/src/main/java/com/playonlinux/services/RemoteAvailableInstallersPlayOnLinuxImplementation.java
+++ b/src/main/java/com/playonlinux/services/RemoteAvailableInstallersPlayOnLinuxImplementation.java
@@ -105,23 +105,7 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
         }
 
         Collections.sort(scripts, new ScriptDTO.AlphabeticalOrderComparator());
-        return () -> scripts.iterator();
-    }
-
-    @Override
-    public Iterable<ScriptDTO> getAllScripts(String filterText) {
-        List<ScriptDTO> scripts = new ArrayList<>();
-        for(CategoryDTO categoryDTO: new ArrayList<>(categoriesDTO)) {
-            for(ScriptDTO scriptDTO: new ArrayList<>(categoryDTO.getScripts())) {
-                if(filterText == null || scriptDTO.getName().contains(filterText)) {
-                    scripts.add(scriptDTO);
-                }
-            }
-        }
-
-        Collections.sort(scripts, new ScriptDTO.AlphabeticalOrderComparator());
-
-        return () -> scripts.iterator();
+        return scripts;
     }
 
     @Override
@@ -139,7 +123,7 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
                 scripts.add(script);
             }
         }
-        return () -> scripts.iterator();
+        return scripts;
     }
 
     @Override

--- a/src/main/java/com/playonlinux/ui/api/InstallerFilter.java
+++ b/src/main/java/com/playonlinux/ui/api/InstallerFilter.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.ui.api;
+
+import com.playonlinux.common.dtos.ScriptDTO;
+import com.playonlinux.common.dtos.ScriptInformationsDTO;
+import com.playonlinux.domain.PlayOnLinuxError;
+import com.playonlinux.utils.OperatingSystem;
+
+import java.util.Observable;
+
+/**
+ * This class is handling the filtering of Installers, providing one central place for
+ * changing how the filtering is done.
+ * InstallerFilters extends Observable, so that changes get directly promoted and
+ * initiate a new filtering process.
+ */
+public class InstallerFilter extends Observable {
+
+    private String title = null;
+    private String category = null;
+    private boolean showTesting = false;
+    private boolean showNoCd = false;
+    private boolean showCommercial = true;
+
+    private final OperatingSystem hostOs;
+
+
+
+    public InstallerFilter(){
+        //TODO: Pre-define filters.
+        OperatingSystem os;
+        try{
+            os = OperatingSystem.fetchCurrentOperationSystem();
+        }catch (PlayOnLinuxError err){
+            os = null;
+        }
+        this.hostOs = os;
+    }
+
+
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) {
+        this.title = title;
+        this.notifyObservers();
+    }
+
+    public String getCategory() { return category; }
+    public void setCategory(String category) {
+        this.category = category;
+        this.notifyObservers();
+    }
+
+    public boolean isShowTesting() { return showTesting; }
+    public void setShowTesting(boolean showTesting) {
+        this.showTesting = showTesting;
+        this.notifyObservers();
+    }
+
+    public boolean isShowNoCd() { return showNoCd; }
+    public void setShowNoCd(boolean showNoCd) {
+        this.showNoCd = showNoCd;
+        this.notifyObservers();
+    }
+
+    public boolean isShowCommercial() { return showCommercial; }
+    public void setShowCommercial(boolean showCommercial) {
+        this.showCommercial = showCommercial;
+        this.notifyObservers();
+    }
+
+
+    /**
+     * Test the given script against the filter rules.
+     * <p>
+     *     Note: At the moment, this method does not filter categories, since Scripts don't know about their own category.
+     * </p>
+     * @param script Script which should be tested against the filter.
+     * @return True if this Script matches the filter criteria, false otherwise.
+     */
+    public boolean apply(ScriptDTO script){
+        //TODO: write testcases for this method.
+        ScriptInformationsDTO scriptInfo = script.getScriptInformations();
+        boolean isTesting = scriptInfo.getTestingOperatingSystems().contains(hostOs);
+
+        if(isTesting && !showTesting){ return false; }
+        if(scriptInfo.isRequiresNoCD() && !showNoCd){ return false; }
+        if(!scriptInfo.isFree() && !showCommercial){ return false; }
+        if(!script.getName().contains(title)){ return false; }
+
+        return true;
+    }
+
+}

--- a/src/main/java/com/playonlinux/ui/api/InstallerFilter.java
+++ b/src/main/java/com/playonlinux/ui/api/InstallerFilter.java
@@ -43,45 +43,58 @@ public class InstallerFilter extends Observable {
     private final OperatingSystem hostOs;
 
 
-
-    public InstallerFilter(){
+    public InstallerFilter() {
         //TODO: Pre-define filters.
         OperatingSystem os;
-        try{
+        try {
             os = OperatingSystem.fetchCurrentOperationSystem();
-        }catch (PlayOnLinuxError err){
+        } catch (PlayOnLinuxError err) {
             os = null;
         }
         this.hostOs = os;
     }
 
 
+    public String getTitle() {
+        return title;
+    }
 
-    public String getTitle() { return title; }
     public void setTitle(String title) {
         this.title = title;
         this.fireUpdate();
     }
 
-    public String getCategory() { return category; }
+    public String getCategory() {
+        return category;
+    }
+
     public void setCategory(String category) {
         this.category = category;
         this.fireUpdate();
     }
 
-    public boolean isShowTesting() { return showTesting; }
+    public boolean isShowTesting() {
+        return showTesting;
+    }
+
     public void setShowTesting(boolean showTesting) {
         this.showTesting = showTesting;
         this.fireUpdate();
     }
 
-    public boolean isShowNoCd() { return showNoCd; }
+    public boolean isShowNoCd() {
+        return showNoCd;
+    }
+
     public void setShowNoCd(boolean showNoCd) {
         this.showNoCd = showNoCd;
         this.fireUpdate();
     }
 
-    public boolean isShowCommercial() { return showCommercial; }
+    public boolean isShowCommercial() {
+        return showCommercial;
+    }
+
     public void setShowCommercial(boolean showCommercial) {
         this.showCommercial = showCommercial;
         this.fireUpdate();
@@ -91,31 +104,37 @@ public class InstallerFilter extends Observable {
     /**
      * Test the given script against the filter rules.
      * <p>
-     *     Note: At the moment, this method does not filter categories, since Scripts don't know about their own category.
+     * Note: At the moment, this method does not filter categories, since Scripts don't know about their own category.
      * </p>
+     *
      * @param script Script which should be tested against the filter.
      * @return True if this Script matches the filter criteria, false otherwise.
      */
-    public boolean apply(ScriptDTO script){
+    public boolean apply(ScriptDTO script) {
         //TODO: write testcases for this method.
         ScriptInformationsDTO scriptInfo = script.getScriptInformations();
         boolean isTesting = scriptInfo.getTestingOperatingSystems().contains(hostOs);
 
-        if(isTesting && !showTesting){ return false; }
-        if(scriptInfo.isRequiresNoCD() && !showNoCd){ return false; }
-        if(!scriptInfo.isFree() && !showCommercial){ return false; }
-        if(StringUtils.isNotBlank(title)) {
-            if(!script.getName().contains(title)){ return false; }
+        if (isTesting && !showTesting) {
+            return false;
+        }
+        if (scriptInfo.isRequiresNoCD() && !showNoCd) {
+            return false;
+        }
+        if (!scriptInfo.isFree() && !showCommercial) {
+            return false;
+        }
+        if (StringUtils.isNotBlank(title)) {
+            if (!script.getName().contains(title)) {
+                return false;
+            }
         }
 
         return true;
     }
 
 
-
-
-
-    private void fireUpdate(){
+    private void fireUpdate() {
         this.setChanged();
         this.notifyObservers();
     }

--- a/src/main/java/com/playonlinux/ui/api/InstallerFilter.java
+++ b/src/main/java/com/playonlinux/ui/api/InstallerFilter.java
@@ -22,6 +22,7 @@ import com.playonlinux.common.dtos.ScriptDTO;
 import com.playonlinux.common.dtos.ScriptInformationsDTO;
 import com.playonlinux.domain.PlayOnLinuxError;
 import com.playonlinux.utils.OperatingSystem;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Observable;
 
@@ -59,31 +60,31 @@ public class InstallerFilter extends Observable {
     public String getTitle() { return title; }
     public void setTitle(String title) {
         this.title = title;
-        this.notifyObservers();
+        this.fireUpdate();
     }
 
     public String getCategory() { return category; }
     public void setCategory(String category) {
         this.category = category;
-        this.notifyObservers();
+        this.fireUpdate();
     }
 
     public boolean isShowTesting() { return showTesting; }
     public void setShowTesting(boolean showTesting) {
         this.showTesting = showTesting;
-        this.notifyObservers();
+        this.fireUpdate();
     }
 
     public boolean isShowNoCd() { return showNoCd; }
     public void setShowNoCd(boolean showNoCd) {
         this.showNoCd = showNoCd;
-        this.notifyObservers();
+        this.fireUpdate();
     }
 
     public boolean isShowCommercial() { return showCommercial; }
     public void setShowCommercial(boolean showCommercial) {
         this.showCommercial = showCommercial;
-        this.notifyObservers();
+        this.fireUpdate();
     }
 
 
@@ -103,9 +104,20 @@ public class InstallerFilter extends Observable {
         if(isTesting && !showTesting){ return false; }
         if(scriptInfo.isRequiresNoCD() && !showNoCd){ return false; }
         if(!scriptInfo.isFree() && !showCommercial){ return false; }
-        if(!script.getName().contains(title)){ return false; }
+        if(StringUtils.isNotBlank(title)) {
+            if(!script.getName().contains(title)){ return false; }
+        }
 
         return true;
+    }
+
+
+
+
+
+    private void fireUpdate(){
+        this.setChanged();
+        this.notifyObservers();
     }
 
 }

--- a/src/main/java/com/playonlinux/ui/api/RemoteAvailableInstallers.java
+++ b/src/main/java/com/playonlinux/ui/api/RemoteAvailableInstallers.java
@@ -36,9 +36,7 @@ public interface RemoteAvailableInstallers extends Iterable<CategoryDTO> {
 
     Iterable<ScriptDTO> getAllScripts();
 
-    Iterable<ScriptDTO> getAllScripts(String filter);
-
-    Iterable<ScriptDTO> getAllScriptsInCategory(String categoryName) throws PlayOnLinuxError;
+    Iterable<ScriptDTO> getAllScripts(InstallerFilter filter) throws PlayOnLinuxError;
 
     ScriptDTO getScriptByName(String scriptName) throws PlayOnLinuxError;
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/AvailableInstallerListWidget.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/AvailableInstallerListWidget.java
@@ -25,7 +25,6 @@ import com.playonlinux.ui.api.RemoteAvailableInstallers;
 import com.playonlinux.ui.impl.javafx.common.SimpleIconListWidget;
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
-import org.apache.commons.lang.StringUtils;
 
 import java.util.Observable;
 import java.util.Observer;
@@ -38,7 +37,9 @@ public class AvailableInstallerListWidget extends SimpleIconListWidget implement
 
     private final InstallerFilter filter = new InstallerFilter();
 
-    public InstallerFilter getFilter(){ return this.filter; }
+    public InstallerFilter getFilter() {
+        return this.filter;
+    }
 
 
     AvailableInstallerListWidget(InstallWindowEventHandler installWindowEventHandler) throws PlayOnLinuxError {
@@ -52,13 +53,13 @@ public class AvailableInstallerListWidget extends SimpleIconListWidget implement
     }
 
     public void update() {
-        if(remoteAvailableInstallers != null) {
+        if (remoteAvailableInstallers != null) {
             this.clear();
             try {
                 for (ScriptDTO script : remoteAvailableInstallers.getAllScripts(filter)) {
                     this.addItem(script.getName());
                 }
-            } catch(PlayOnLinuxError playOnLinuxError){
+            } catch (PlayOnLinuxError playOnLinuxError) {
                 Alert alert = new Alert(Alert.AlertType.ERROR);
                 alert.setTitle(translate("Error while trying to show installer list."));
                 alert.setContentText(String.format("The error was: %s", playOnLinuxError));

--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
@@ -243,7 +243,7 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
                 playOnLinuxError.printStackTrace();
             }
         });
-        searchWidget.setOnKeyPressed(event -> availableInstallerListWidget.getFilter().setTitle(searchWidget.getText()));
+        searchWidget.setOnKeyReleased(event -> availableInstallerListWidget.getFilter().setTitle(searchWidget.getText()));
         testingCheck.setOnAction(event -> availableInstallerListWidget.getFilter().setShowTesting(testingCheck.isSelected()));
         noCdNeededCheck.setOnAction(event -> availableInstallerListWidget.getFilter().setShowNoCd(noCdNeededCheck.isSelected()));
         commercialCheck.setOnAction(event -> availableInstallerListWidget.getFilter().setShowCommercial(commercialCheck.isSelected()));

--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
@@ -72,11 +72,12 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
     /**
      * Get the instance of the configure window.
      * The singleton pattern is only meant to avoid opening this window twice.
+     *
      * @param parent
      * @return the install window instance
      */
     public static InstallWindow getInstance(PlayOnLinuxWindow parent) throws PlayOnLinuxError {
-        if(instance == null) {
+        if (instance == null) {
             instance = new InstallWindow(parent);
         } else {
             instance.toFront();
@@ -264,9 +265,9 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
     }
 
     public void update(RemoteAvailableInstallers remoteAvailableInstallers) {
-        if(remoteAvailableInstallers.isUpdating()) {
+        if (remoteAvailableInstallers.isUpdating()) {
             this.showUpdateScene();
-        } else if(remoteAvailableInstallers.hasFailed()) {
+        } else if (remoteAvailableInstallers.hasFailed()) {
             this.showFailureScene();
         } else {
             this.showMainScene();

--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
@@ -68,6 +68,7 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
     public AvailableInstallerListWidget getAvailableInstallerListWidget() {
         return availableInstallerListWidget;
     }
+
     /**
      * Get the instance of the configure window.
      * The singleton pattern is only meant to avoid opening this window twice.
@@ -203,7 +204,6 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
     }
 
 
-
     private void showMainScene() {
         this.setScene(mainScene);
     }
@@ -242,10 +242,10 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
                 playOnLinuxError.printStackTrace();
             }
         });
-        searchWidget.setOnKeyPressed(event -> availableInstallerListWidget.setSearchFilter(searchWidget.getText()));
-        testingCheck.setOnAction(event -> availableInstallerListWidget.setIncludeTesting(testingCheck.isSelected()));
-        noCdNeededCheck.setOnAction(event -> availableInstallerListWidget.setIncludeNoCDNeeded(noCdNeededCheck.isSelected()));
-        commercialCheck.setOnAction(event -> availableInstallerListWidget.setIncludeCommercial(commercialCheck.isSelected()));
+        searchWidget.setOnKeyPressed(event -> availableInstallerListWidget.getFilter().setTitle(searchWidget.getText()));
+        testingCheck.setOnAction(event -> availableInstallerListWidget.getFilter().setShowTesting(testingCheck.isSelected()));
+        noCdNeededCheck.setOnAction(event -> availableInstallerListWidget.getFilter().setShowNoCd(noCdNeededCheck.isSelected()));
+        commercialCheck.setOnAction(event -> availableInstallerListWidget.getFilter().setShowCommercial(commercialCheck.isSelected()));
 
         availableInstallerListWidget.setOnMouseClicked(event -> {
             if (event.getClickCount() == 2) {
@@ -257,7 +257,6 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
         refreshButton.setOnMouseClicked(event -> eventHandler.updateAvailableInstallers());
         retryButton.setOnMouseClicked(event -> eventHandler.updateAvailableInstallers());
     }
-
 
 
     public InstallWindowEventHandler getEventHandler() {
@@ -283,7 +282,7 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
 
     public void clearSearch() {
         searchWidget.clear();
-        availableInstallerListWidget.setSearchFilter("");
+        availableInstallerListWidget.getFilter().setTitle(null);
     }
 }
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindowEventHandler.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindowEventHandler.java
@@ -50,7 +50,7 @@ public class InstallWindowEventHandler implements UIEventHandler {
     }
 
     public void selectCategory(String categoryName) {
-        installWindow.getAvailableInstallerListWidget().setCategoryName(categoryName);
+        installWindow.getAvailableInstallerListWidget().getFilter().setCategory(categoryName);
     }
 
     public String getInstallerDescription(String scriptName) throws PlayOnLinuxError {


### PR DESCRIPTION
I've refactored the filtering for Installer-Scripts displayed in the InstallWindow.
This is a fix for #24.

Abstract:
I created a class (InstallerFilter) which handles all filter parameters as well as the filtering itself. This extracts the filter-logic out of the View-Part (AvailableInstallerList) and gives us a central point where we can easily change this behavior or add new parameters. InstallerFilter is an Observable, automatically notifying observers (the AvailableInstallerList) that the filter-parameters have changed, causing a refiltering and a UI refresh.