### PR TITLE
[WIP] Filter standardization and refactoring for Installers. Version 2

### DIFF
--- a/src/main/java/com/playonlinux/services/RemoteAvailableInstallersPlayOnLinuxImplementation.java
+++ b/src/main/java/com/playonlinux/services/RemoteAvailableInstallersPlayOnLinuxImplementation.java
@@ -67,7 +67,7 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
         downloadEnvelopeDto = (DownloadEnvelopeDTO<AvailableCategoriesDTO>) arg;
 
         try {
-            if(downloadEnvelopeDto.getEnvelopeContent() != null) {
+            if (downloadEnvelopeDto.getEnvelopeContent() != null) {
                 List<CategoryDTO> availableCategories = new ArrayList<>(
                         downloadEnvelopeDto.getEnvelopeContent().getCategories()
                 );
@@ -98,13 +98,11 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
     }
 
 
-
-
     @Override
     public Iterable<ScriptDTO> getList() {
         List<ScriptDTO> scripts = new ArrayList<>();
-        for(CategoryDTO categoryDTO: new ArrayList<>(categoriesDTO)) {
-            for(ScriptDTO scriptDTO: new ArrayList<>(categoryDTO.getScripts())) {
+        for (CategoryDTO categoryDTO : new ArrayList<>(categoriesDTO)) {
+            for (ScriptDTO scriptDTO : new ArrayList<>(categoryDTO.getScripts())) {
                 scripts.add(scriptDTO);
             }
         }
@@ -116,15 +114,15 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
     @Override
     public Iterable<ScriptDTO> getFilteredList() throws PlayOnLinuxError {
         Iterable<ScriptDTO> scriptsToFilter;
-        if(filter.getCategory() == null){
+        if (filter.getCategory() == null) {
             scriptsToFilter = getList();
-        }else{
+        } else {
             scriptsToFilter = getAllScriptsInCategory(filter.getCategory());
         }
 
         List<ScriptDTO> scripts = new ArrayList<>();
-        for(ScriptDTO script : scriptsToFilter){
-            if(getFilter().apply(script)){
+        for (ScriptDTO script : scriptsToFilter) {
+            if (getFilter().apply(script)) {
                 scripts.add(script);
             }
         }
@@ -133,15 +131,15 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
 
 
     @Override
-    public InstallerFilter getFilter(){
+    public InstallerFilter getFilter() {
         return this.filter;
     }
 
 
     @Override
     public ScriptDTO getByName(String scriptName) throws PlayOnLinuxError {
-        for(ScriptDTO scriptDTO: this.getList()) {
-            if(scriptName.equals(scriptDTO.getName())) {
+        for (ScriptDTO scriptDTO : this.getList()) {
+            if (scriptName.equals(scriptDTO.getName())) {
                 return scriptDTO;
             }
         }
@@ -151,7 +149,7 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
 
     @Override
     public void refresh() {
-        if(remoteAvailableInstallers != null) {
+        if (remoteAvailableInstallers != null) {
             remoteAvailableInstallers.deleteObserver(this);
             playOnLinuxBackgroundServicesManager.unregister(remoteAvailableInstallers);
         }
@@ -161,8 +159,8 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
     }
 
     private Iterable<ScriptDTO> getAllScriptsInCategory(String categoryName) throws PlayOnLinuxError {
-        for(CategoryDTO categoryDTO: categoriesDTO) {
-            if(categoryName.equals(categoryDTO.getName())) {
+        for (CategoryDTO categoryDTO : categoriesDTO) {
+            if (categoryName.equals(categoryDTO.getName())) {
                 return getAllScriptsInCategory(categoryDTO);
             }
         }
@@ -171,7 +169,7 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
 
     private Iterable<ScriptDTO> getAllScriptsInCategory(CategoryDTO categoryDTO) {
         List<ScriptDTO> scripts = new ArrayList<>();
-        for(ScriptDTO scriptDTO: new ArrayList<>(categoryDTO.getScripts())) {
+        for (ScriptDTO scriptDTO : new ArrayList<>(categoryDTO.getScripts())) {
             scripts.add(scriptDTO);
         }
 
@@ -181,12 +179,11 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
     }
 
 
-
     public class InstallerFilter extends com.playonlinux.ui.api.RemoteAvailableInstallers.InstallerFilter {
 
         private final OperatingSystem hostOs;
 
-        public InstallerFilter(){
+        public InstallerFilter() {
             //predefine filters
             title = null;
             category = null;
@@ -195,24 +192,30 @@ public class RemoteAvailableInstallersPlayOnLinuxImplementation extends Observab
             showCommercial = true;
 
             OperatingSystem os;
-            try{
+            try {
                 os = OperatingSystem.fetchCurrentOperationSystem();
-            }catch (PlayOnLinuxError err){
+            } catch (PlayOnLinuxError err) {
                 os = null;
             }
             this.hostOs = os;
         }
 
         @Override
-        public boolean apply(ScriptDTO script){
+        public boolean apply(ScriptDTO script) {
             //TODO: write testcases for this method.
             ScriptInformationsDTO scriptInfo = script.getScriptInformations();
             boolean isTesting = scriptInfo.getTestingOperatingSystems().contains(hostOs);
 
-            if(isTesting && !showTesting){ return false; }
-            if(scriptInfo.isRequiresNoCD() && !showNoCd){ return false; }
-            if(!scriptInfo.isFree() && !showCommercial){ return false; }
-            if(StringUtils.isNotBlank(title) && !script.getName().contains(title)){
+            if (isTesting && !showTesting) {
+                return false;
+            }
+            if (scriptInfo.isRequiresNoCD() && !showNoCd) {
+                return false;
+            }
+            if (!scriptInfo.isFree() && !showCommercial) {
+                return false;
+            }
+            if (StringUtils.isNotBlank(title) && !script.getName().contains(title)) {
                 return false;
             }
 

--- a/src/main/java/com/playonlinux/ui/api/Filter.java
+++ b/src/main/java/com/playonlinux/ui/api/Filter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.playonlinux.ui.api;
 
 import java.util.Observer;
@@ -9,8 +27,9 @@ public interface Filter<DTO> {
     /**
      * Test the given script against the filter rules.
      * <p>
-     *     Note: At the moment, this method does not filter categories, since Scripts don't know about their own category.
+     * Note: At the moment, this method does not filter categories, since Scripts don't know about their own category.
      * </p>
+     *
      * @param dto DTO which should be tested against the filter.
      * @return True if this Script matches the filter criteria, false otherwise.
      */

--- a/src/main/java/com/playonlinux/ui/api/Filter.java
+++ b/src/main/java/com/playonlinux/ui/api/Filter.java
@@ -1,0 +1,19 @@
+package com.playonlinux.ui.api;
+
+import java.util.Observer;
+
+public interface Filter<DTO> {
+
+    void addObserver(Observer o);
+
+    /**
+     * Test the given script against the filter rules.
+     * <p>
+     *     Note: At the moment, this method does not filter categories, since Scripts don't know about their own category.
+     * </p>
+     * @param dto DTO which should be tested against the filter.
+     * @return True if this Script matches the filter criteria, false otherwise.
+     */
+    boolean apply(DTO dto);
+
+}

--- a/src/main/java/com/playonlinux/ui/api/Filterable.java
+++ b/src/main/java/com/playonlinux/ui/api/Filterable.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.ui.api;
+
+import com.playonlinux.domain.PlayOnLinuxError;
+
+/**
+ * Filterable defines methods to use an instance of DTO as container for filter-parameters.
+ * @param <DTO> The DTO to use for filtering.
+ */
+
+public interface Filterable<DTO> {
+
+    Filter<DTO> getFilter();
+
+    Iterable<DTO> getFilteredList() throws PlayOnLinuxError;
+
+}

--- a/src/main/java/com/playonlinux/ui/api/RemoteAvailableInstallers.java
+++ b/src/main/java/com/playonlinux/ui/api/RemoteAvailableInstallers.java
@@ -20,12 +20,14 @@ package com.playonlinux.ui.api;
 
 import com.playonlinux.common.dtos.CategoryDTO;
 import com.playonlinux.common.dtos.ScriptDTO;
+import com.playonlinux.common.dtos.ScriptInformationsDTO;
 import com.playonlinux.domain.PlayOnLinuxError;
+import com.playonlinux.utils.OperatingSystem;
 
-import java.util.Iterator;
+import java.util.Observable;
 import java.util.Observer;
 
-public interface RemoteAvailableInstallers extends Iterable<CategoryDTO> {
+public interface RemoteAvailableInstallers extends Iterable<CategoryDTO>, Filterable<ScriptDTO> {
     void addObserver(Observer o);
 
     int getNumberOfCategories();
@@ -34,13 +36,67 @@ public interface RemoteAvailableInstallers extends Iterable<CategoryDTO> {
 
     boolean hasFailed();
 
-    Iterable<ScriptDTO> getAllScripts();
+    Iterable<ScriptDTO> getList();
 
-    Iterable<ScriptDTO> getAllScripts(String filter);
+    InstallerFilter getFilter();
 
-    Iterable<ScriptDTO> getAllScriptsInCategory(String categoryName) throws PlayOnLinuxError;
-
-    ScriptDTO getScriptByName(String scriptName) throws PlayOnLinuxError;
+    ScriptDTO getByName(String scriptName) throws PlayOnLinuxError;
 
     void refresh();
+
+
+    /**
+     * This class is handling the filtering of Installers, providing one central place for
+     * changing how the filtering is done.
+     * InstallerFilters extends Observable, so that changes get directly promoted and
+     * initiate a new filtering process.
+     */
+    abstract class InstallerFilter extends Observable implements Filter<ScriptDTO> {
+
+        protected String title;
+        protected String category;
+        protected boolean showTesting;
+        protected boolean showNoCd;
+        protected boolean showCommercial;
+
+        public String getTitle() { return title; }
+        public void setTitle(String title) {
+            //prevent unnecessary filtering
+            if(this.title != title){
+                this.title = title;
+                this.fireUpdate();
+            }
+        }
+
+        public String getCategory() { return category; }
+        public void setCategory(String category) {
+            this.category = category;
+            this.fireUpdate();
+        }
+
+        public boolean isShowTesting() { return showTesting; }
+        public void setShowTesting(boolean showTesting) {
+            this.showTesting = showTesting;
+            this.fireUpdate();
+        }
+
+        public boolean isShowNoCd() { return showNoCd; }
+        public void setShowNoCd(boolean showNoCd) {
+            this.showNoCd = showNoCd;
+            this.fireUpdate();
+        }
+
+        public boolean isShowCommercial() { return showCommercial; }
+        public void setShowCommercial(boolean showCommercial) {
+            this.showCommercial = showCommercial;
+            this.fireUpdate();
+        }
+
+        private void fireUpdate(){
+            this.setChanged();
+            this.notifyObservers();
+        }
+
+    }
+
 }

--- a/src/main/java/com/playonlinux/ui/api/RemoteAvailableInstallers.java
+++ b/src/main/java/com/playonlinux/ui/api/RemoteAvailableInstallers.java
@@ -59,40 +59,55 @@ public interface RemoteAvailableInstallers extends Iterable<CategoryDTO>, Filter
         protected boolean showNoCd;
         protected boolean showCommercial;
 
-        public String getTitle() { return title; }
+        public String getTitle() {
+            return title;
+        }
+
         public void setTitle(String title) {
             //prevent unnecessary filtering
-            if(this.title != title){
+            if (this.title != title) {
                 this.title = title;
                 this.fireUpdate();
             }
         }
 
-        public String getCategory() { return category; }
+        public String getCategory() {
+            return category;
+        }
+
         public void setCategory(String category) {
             this.category = category;
             this.fireUpdate();
         }
 
-        public boolean isShowTesting() { return showTesting; }
+        public boolean isShowTesting() {
+            return showTesting;
+        }
+
         public void setShowTesting(boolean showTesting) {
             this.showTesting = showTesting;
             this.fireUpdate();
         }
 
-        public boolean isShowNoCd() { return showNoCd; }
+        public boolean isShowNoCd() {
+            return showNoCd;
+        }
+
         public void setShowNoCd(boolean showNoCd) {
             this.showNoCd = showNoCd;
             this.fireUpdate();
         }
 
-        public boolean isShowCommercial() { return showCommercial; }
+        public boolean isShowCommercial() {
+            return showCommercial;
+        }
+
         public void setShowCommercial(boolean showCommercial) {
             this.showCommercial = showCommercial;
             this.fireUpdate();
         }
 
-        private void fireUpdate(){
+        private void fireUpdate() {
             this.setChanged();
             this.notifyObservers();
         }

--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/AvailableInstallerListWidget.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/AvailableInstallerListWidget.java
@@ -35,62 +35,63 @@ public class AvailableInstallerListWidget extends SimpleIconListWidget implement
     private final InstallWindowEventHandler installWindowEventHandler;
     private RemoteAvailableInstallers remoteAvailableInstallers;
 
-    public void setCategoryName(String categoryName) {
-        this.categoryName = categoryName;
-        this.update();
+    public RemoteAvailableInstallers.InstallerFilter getFilter(){
+        return remoteAvailableInstallers.getFilter();
     }
 
-    public void setIncludeCommercial(boolean includeCommercial) {
-        this.includeCommercial = includeCommercial;
-        this.update();
-    }
-
-    public void setIncludeNoCDNeeded(boolean includeNoCDNeeded) {
-        this.includeNoCDNeeded = includeNoCDNeeded;
-        this.update();
-    }
-
-    public void setIncludeTesting(boolean includeTesting) {
-        this.includeTesting = includeTesting;
-        this.update();
-    }
-
-    public void setSearchFilter(String searchFilter) {
-        this.searchFilter = searchFilter;
-        this.update();
-    }
-
-    private String categoryName;
-    private boolean includeTesting = false;
-    private boolean includeNoCDNeeded = false;
-    private boolean includeCommercial = true;
-    private String searchFilter = "";
+//    public void setCategoryName(String categoryName) {
+//        this.categoryName = categoryName;
+//        this.update();
+//    }
+//
+//    public void setIncludeCommercial(boolean includeCommercial) {
+//        this.includeCommercial = includeCommercial;
+//        this.update();
+//    }
+//
+//    public void setIncludeNoCDNeeded(boolean includeNoCDNeeded) {
+//        this.includeNoCDNeeded = includeNoCDNeeded;
+//        this.update();
+//    }
+//
+//    public void setIncludeTesting(boolean includeTesting) {
+//        this.includeTesting = includeTesting;
+//        this.update();
+//    }
+//
+//    public void setSearchFilter(String searchFilter) {
+//        this.searchFilter = searchFilter;
+//        this.update();
+//    }
+//
+//    private String categoryName;
+//    private boolean includeTesting = false;
+//    private boolean includeNoCDNeeded = false;
+//    private boolean includeCommercial = true;
+//    private String searchFilter = "";
 
     AvailableInstallerListWidget(InstallWindowEventHandler installWindowEventHandler) throws PlayOnLinuxError {
         super();
         this.installWindowEventHandler = installWindowEventHandler;
         this.installWindowEventHandler.getRemoteAvailableInstallers().addObserver(this);
         remoteAvailableInstallers = this.installWindowEventHandler.getRemoteAvailableInstallers();
+
+        remoteAvailableInstallers.getFilter().addObserver((observable, o) -> update());
     }
 
     public void update() {
         if(remoteAvailableInstallers != null) {
             this.clear();
-            if(!StringUtils.isBlank(searchFilter)) {
-                for(ScriptDTO scriptDTO : remoteAvailableInstallers.getAllScripts(searchFilter)) {
-                    this.addItem(scriptDTO.getName());
+            try {
+                for (ScriptDTO script : remoteAvailableInstallers.getFilteredList()) {
+                    this.addItem(script.getName());
                 }
-            } else if (categoryName != null) {
-                try {
-                    for(ScriptDTO scriptDTO: remoteAvailableInstallers.getAllScriptsInCategory(categoryName)) {
-                        this.addItem(scriptDTO.getName());
-                    }
-                } catch (PlayOnLinuxError playOnLinuxError) {
-                    Alert alert = new Alert(Alert.AlertType.ERROR);
-                    alert.setTitle(translate("Error while trying to show installer list."));
-                    alert.setContentText(String.format("The error was: %s", playOnLinuxError));
-                    playOnLinuxError.printStackTrace();
-                }
+            } catch (PlayOnLinuxError playOnLinuxError) {
+                Alert alert = new Alert(Alert.AlertType.ERROR);
+                alert.setTitle(translate("Error while trying to show installer list."));
+                alert.setContentText(String.format("The error was: %s", playOnLinuxError));
+                playOnLinuxError.printStackTrace();
+                alert.show();
             }
         }
     }

--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
@@ -242,7 +242,7 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
                 playOnLinuxError.printStackTrace();
             }
         });
-        searchWidget.setOnKeyPressed(event -> availableInstallerListWidget.setSearchFilter(searchWidget.getText()));
+        searchWidget.setOnKeyReleased(event -> availableInstallerListWidget.setSearchFilter(searchWidget.getText()));
         testingCheck.setOnAction(event -> availableInstallerListWidget.setIncludeTesting(testingCheck.isSelected()));
         noCdNeededCheck.setOnAction(event -> availableInstallerListWidget.setIncludeNoCDNeeded(noCdNeededCheck.isSelected()));
         commercialCheck.setOnAction(event -> availableInstallerListWidget.setIncludeCommercial(commercialCheck.isSelected()));

--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
@@ -242,10 +242,10 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
                 playOnLinuxError.printStackTrace();
             }
         });
-        searchWidget.setOnKeyReleased(event -> availableInstallerListWidget.setSearchFilter(searchWidget.getText()));
-        testingCheck.setOnAction(event -> availableInstallerListWidget.setIncludeTesting(testingCheck.isSelected()));
-        noCdNeededCheck.setOnAction(event -> availableInstallerListWidget.setIncludeNoCDNeeded(noCdNeededCheck.isSelected()));
-        commercialCheck.setOnAction(event -> availableInstallerListWidget.setIncludeCommercial(commercialCheck.isSelected()));
+        searchWidget.setOnKeyReleased(event -> availableInstallerListWidget.getFilter().setTitle(searchWidget.getText()));
+        testingCheck.setOnAction(event -> availableInstallerListWidget.getFilter().setShowTesting(testingCheck.isSelected()));
+        noCdNeededCheck.setOnAction(event -> availableInstallerListWidget.getFilter().setShowNoCd(noCdNeededCheck.isSelected()));
+        commercialCheck.setOnAction(event -> availableInstallerListWidget.getFilter().setShowCommercial(commercialCheck.isSelected()));
 
         availableInstallerListWidget.setOnMouseClicked(event -> {
             if (event.getClickCount() == 2) {
@@ -283,7 +283,7 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
 
     public void clearSearch() {
         searchWidget.clear();
-        availableInstallerListWidget.setSearchFilter("");
+        availableInstallerListWidget.getFilter().setTitle("");
     }
 }
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindow.java
@@ -68,14 +68,16 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
     public AvailableInstallerListWidget getAvailableInstallerListWidget() {
         return availableInstallerListWidget;
     }
+
     /**
      * Get the instance of the configure window.
      * The singleton pattern is only meant to avoid opening this window twice.
+     *
      * @param parent
      * @return the install window instance
      */
     public static InstallWindow getInstance(PlayOnLinuxWindow parent) throws PlayOnLinuxError {
-        if(instance == null) {
+        if (instance == null) {
             instance = new InstallWindow(parent);
         } else {
             instance.toFront();
@@ -203,7 +205,6 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
     }
 
 
-
     private void showMainScene() {
         this.setScene(mainScene);
     }
@@ -259,15 +260,14 @@ public class InstallWindow extends Stage implements PlayOnLinuxWindow, Observer 
     }
 
 
-
     public InstallWindowEventHandler getEventHandler() {
         return eventHandler;
     }
 
     public void update(RemoteAvailableInstallers remoteAvailableInstallers) {
-        if(remoteAvailableInstallers.isUpdating()) {
+        if (remoteAvailableInstallers.isUpdating()) {
             this.showUpdateScene();
-        } else if(remoteAvailableInstallers.hasFailed()) {
+        } else if (remoteAvailableInstallers.hasFailed()) {
             this.showFailureScene();
         } else {
             this.showMainScene();

--- a/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindowEventHandler.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/installwindow/InstallWindowEventHandler.java
@@ -50,11 +50,11 @@ public class InstallWindowEventHandler implements UIEventHandler {
     }
 
     public void selectCategory(String categoryName) {
-        installWindow.getAvailableInstallerListWidget().setCategoryName(categoryName);
+        installWindow.getAvailableInstallerListWidget().getFilter().setCategory(categoryName);
     }
 
     public String getInstallerDescription(String scriptName) throws PlayOnLinuxError {
-        return getRemoteAvailableInstallers().getScriptByName(scriptName).getDescription();
+        return getRemoteAvailableInstallers().getByName(scriptName).getDescription();
     }
 
     public void installProgram(String selectedItemLabel) {


### PR DESCRIPTION
A standardization for the UI how the Filtering of DTO's should be handled.
I've refactored the filtering for Installer-Scripts displayed in the InstallWindow.
This is a fix for #24.

Abstract:
The interface Filterable<DTO> defines how a container of DTO's should look for being filterable. The Filter<DTO> interface defines how the filter (doing the actual filtering) should look and work like.

Every container of DTO's then needs an own implementation of Filter<DTO> to be able to export all filter-parameters to the callers. In the case of Installers, this is done with the abstract class within `RemoteAvailableInstallers`, only defining the Filter's getters and setters.