### PR TITLE
Create an interface for classes that need instant cleanup.

### DIFF
--- a/src/main/java/com/playonlinux/common/api/Disposable.java
+++ b/src/main/java/com/playonlinux/common/api/Disposable.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.common.api;
+
+/**
+ * Defines how a disposable class should look and behave.
+ */
+public interface Disposable {
+
+    /**
+     * Cause this class to cleanup its resources.
+     */
+    void dispose();
+
+}


### PR DESCRIPTION
The `dispose()` method adds the functionality for directly telling a class to clean itself up if necessary.
This is the point where resources like streams should be closed.