### PR TITLE
Use PO files for translation like gettext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
             <artifactId>log4j</artifactId>
             <version>1.2.17</version>
         </dependency>
+        <dependency>
+            <groupId>org.fedorahosted.tennera</groupId>
+            <artifactId>jgettext</artifactId>
+            <version>0.14</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/src/main/java/com/playonlinux/app/PlayOnLinuxConfig.java
+++ b/src/main/java/com/playonlinux/app/PlayOnLinuxConfig.java
@@ -25,6 +25,8 @@ import com.playonlinux.common.api.webservice.InstallerSource;
 import com.playonlinux.common.services.EventHandlerPlayOnLinuxImplementation;
 import com.playonlinux.common.services.PlayOnLinuxBackgroundServicesManager;
 import com.playonlinux.domain.PlayOnLinuxException;
+import com.playonlinux.domain.lang.LanguageBundle;
+import com.playonlinux.domain.lang.LanguageBundleSelector;
 import com.playonlinux.injection.AbstractConfigFile;
 import com.playonlinux.injection.Bean;
 import com.playonlinux.ui.impl.cli.ControllerCLIImplementation;
@@ -34,6 +36,7 @@ import com.playonlinux.webservice.InstallerSourceWebserviceImplementation;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Locale;
 
 @SuppressWarnings("unused")
 public class PlayOnLinuxConfig extends AbstractConfigFile  {
@@ -68,6 +71,11 @@ public class PlayOnLinuxConfig extends AbstractConfigFile  {
     @Bean
     public BackgroundServiceManager playOnLinuxBackgroundServicesManager() {
         return new PlayOnLinuxBackgroundServicesManager();
+    }
+
+    @Bean
+    public LanguageBundle languageBundle() {
+        return LanguageBundleSelector.forLocale(Locale.getDefault());
     }
 
     @Override

--- a/src/main/java/com/playonlinux/domain/Localisation.java
+++ b/src/main/java/com/playonlinux/domain/Localisation.java
@@ -19,14 +19,15 @@
 package com.playonlinux.domain;
 
 import com.playonlinux.app.PlayOnLinuxContext;
+import com.playonlinux.domain.lang.LanguageBundle;
 import com.playonlinux.injection.Inject;
 import com.playonlinux.injection.Scan;
 import com.playonlinux.utils.ReplacableProperties;
 
-
-// TODO
 @Scan
 public final class Localisation {
+    @Inject
+    private static LanguageBundle bundle;
     @Inject
     private static PlayOnLinuxContext playOnLinuxContext;
 
@@ -39,6 +40,6 @@ public final class Localisation {
         ReplacableProperties properties;
         properties = playOnLinuxContext.loadProperties();
 
-        return properties.replaceAllVariables(stringToTranslate);
+        return properties.replaceAllVariables(bundle.translate(stringToTranslate));
     }
 }

--- a/src/main/java/com/playonlinux/domain/lang/CatalogLanguageBundle.java
+++ b/src/main/java/com/playonlinux/domain/lang/CatalogLanguageBundle.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 Jonas Konrad
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.domain.lang;
+
+import com.google.common.base.Preconditions;
+import org.fedorahosted.tennera.jgettext.Catalog;
+import org.fedorahosted.tennera.jgettext.Message;
+
+/**
+ * Language bundle from gnu gettext PO files using jgettext.
+ */
+public class CatalogLanguageBundle implements LanguageBundle {
+    private final Catalog catalog;
+
+    public CatalogLanguageBundle(Catalog catalog) {
+        this.catalog = catalog;
+    }
+
+    @Override
+    public String translate(String toTranslate) {
+        // toTranslate null check below
+        return translate(null, toTranslate);
+    }
+
+    @Override
+    public String translate(String context, String toTranslate) {
+        Preconditions.checkNotNull(toTranslate, "toTranslate");
+
+        Message message = catalog.locateMessage(context, toTranslate);
+        if (message == null) {
+            return toTranslate;
+        } else {
+            return message.getMsgstr();
+        }
+    }
+}

--- a/src/main/java/com/playonlinux/domain/lang/FallbackLanguageBundle.java
+++ b/src/main/java/com/playonlinux/domain/lang/FallbackLanguageBundle.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 Jonas Konrad
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.domain.lang;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * LanguageBundle that doesn't translate at all.
+ */
+public class FallbackLanguageBundle implements LanguageBundle {
+    private static final FallbackLanguageBundle instance = new FallbackLanguageBundle();
+
+    public static FallbackLanguageBundle getInstance() {
+        return instance;
+    }
+
+    private FallbackLanguageBundle() {}
+
+    @Override
+    public String translate(String toTranslate) {
+        Preconditions.checkNotNull(toTranslate, "toTranslate");
+        return toTranslate;
+    }
+
+    @Override
+    public String translate(String context, String toTranslate) {
+        Preconditions.checkNotNull(toTranslate, "toTranslate");
+        return toTranslate;
+    }
+}

--- a/src/main/java/com/playonlinux/domain/lang/LanguageBundle.java
+++ b/src/main/java/com/playonlinux/domain/lang/LanguageBundle.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Jonas Konrad
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.domain.lang;
+
+/**
+ * Interface to translate UI strings to different languages.
+ */
+public interface LanguageBundle {
+    /**
+     * Try to translate the given message in with this bundle in the default context.
+     *
+     * @param toTranslate The string to translate.
+     * @return The translated string or <code>toTranslate</code> if this string could not be translated with this
+     * bundle. Never null.
+     * @throws NullPointerException if toTranslate is null.
+     */
+    String translate(String toTranslate);
+
+    /**
+     * Try to translate the given message in the given context with this bundle.
+     *
+     * @param toTranslate The string to translate.
+     * @param context     The context ID in which to translate this string. May be null.
+     * @return The translated string or <code>toTranslate</code> if this string could not be translated with this
+     * bundle. Never null.
+     * @throws NullPointerException if toTranslate is null.
+     */
+    String translate(String context, String toTranslate);
+}

--- a/src/main/java/com/playonlinux/domain/lang/LanguageBundleSelector.java
+++ b/src/main/java/com/playonlinux/domain/lang/LanguageBundleSelector.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 Jonas Konrad
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.domain.lang;
+
+import com.playonlinux.domain.Localisation;
+import java.io.IOError;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Locale;
+import org.fedorahosted.tennera.jgettext.PoParser;
+
+public class LanguageBundleSelector {
+    /**
+     * Select a LanguageBundle for the given resource from the classpath.
+     *
+     * @return The language bundle, never null. May be a {@link FallbackLanguageBundle} which will do a no-operation
+     * translation.
+     */
+    public static LanguageBundle forLocale(Locale locale) {
+        // first, try the full language-country tag (either xx-YY or just xx if no country was specified)
+        String fullTag = new Locale(locale.getLanguage(), locale.getCountry())
+                .toLanguageTag().replace('-', '_');
+        LanguageBundle bundle = forLocaleIdOrNull(fullTag);
+        if (bundle != null) { return bundle; }
+
+        // then, try the base language tag (just xx for language)
+        String languageTag = new Locale(locale.getLanguage())
+                .toLanguageTag().replace('-', '_');
+        bundle = forLocaleIdOrNull(languageTag);
+        if (bundle != null) { return bundle; }
+
+        // if neither was found, fall back on defaults
+        return FallbackLanguageBundle.getInstance();
+    }
+
+    private static CatalogLanguageBundle forLocaleIdOrNull(String localeId) {
+        URL poResourceUrl = Localisation.class.getResource("/locale/po/" + localeId + ".po");
+        if (poResourceUrl == null) {
+            return null;
+        } else {
+            return parseCatalogBundle(poResourceUrl);
+        }
+    }
+
+    private static CatalogLanguageBundle parseCatalogBundle(URL poResourceUrl) {
+        PoParser parser = new PoParser();
+        try (InputStream inputStream = poResourceUrl.openStream()) {
+            return new CatalogLanguageBundle(parser.parseCatalog(inputStream, false));
+        } catch (IOException e) {
+            // this should only happen if a PO file is broken so we throw an Error
+            throw new IOError(e);
+        }
+    }
+}

--- a/src/test/java/com/playonlinux/domain/lang/LanguageBundleSelectorTest.java
+++ b/src/test/java/com/playonlinux/domain/lang/LanguageBundleSelectorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 Jonas Konrad
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.domain.lang;
+
+import java.util.Locale;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LanguageBundleSelectorTest {
+    @Test
+    public void testMissingCountry() {
+        // Test a locale has language and country and should fall back on language
+        LanguageBundle bundle = LanguageBundleSelector.forLocale(Locale.GERMANY);
+        assertEquals("Fehler melden", bundle.translate("Report a bug"));
+    }
+
+    @Test
+    public void testCountry() {
+        // Test a locale has language and country
+        LanguageBundle bundle = LanguageBundleSelector.forLocale(new Locale("pt", "br"));
+        assertEquals("Relatar um problema (bug)", bundle.translate("Report a bug"));
+    }
+
+    @Test
+    public void testLanguage() {
+        // Test a locale that only has a language
+        LanguageBundle bundle = LanguageBundleSelector.forLocale(Locale.GERMAN);
+        assertEquals("Fehler melden", bundle.translate("Report a bug"));
+    }
+
+    @Test
+    public void testFallback() {
+        // Test an unsupported locale
+        // todo: use a language that doesn't return "undefined" for the language tag? i.e. real language
+        LanguageBundle bundle = LanguageBundleSelector.forLocale(new Locale("##", "##"));
+        assertEquals("Report a bug", bundle.translate("Report a bug"));
+    }
+}

--- a/src/test/java/com/playonlinux/framework/SetupWizardTest.java
+++ b/src/test/java/com/playonlinux/framework/SetupWizardTest.java
@@ -22,6 +22,8 @@ import com.playonlinux.common.api.ui.Controller;
 import com.playonlinux.app.PlayOnLinuxContext;
 import com.playonlinux.domain.CancelException;
 import com.playonlinux.domain.PlayOnLinuxException;
+import com.playonlinux.domain.lang.FallbackLanguageBundle;
+import com.playonlinux.domain.lang.LanguageBundle;
 import com.playonlinux.injection.AbstractConfigFile;
 import com.playonlinux.injection.Bean;
 import com.playonlinux.injection.InjectionException;
@@ -56,6 +58,11 @@ public class SetupWizardTest {
         @Bean
         protected PlayOnLinuxContext playOnLinuxContext() throws PlayOnLinuxException, IOException {
             return new PlayOnLinuxContext();
+        }
+
+        @Bean
+        protected LanguageBundle languageBundle() {
+            return FallbackLanguageBundle.getInstance();
         }
     }
 


### PR DESCRIPTION
Not entirely happy with injecting a static field but the basic implementation is there. Tested with German language in the existing interface.

- I'm not sure how to handle the zh_CN ; zh_TW pair since neither specify the top-level zh language.
- en_GB also isn't used as default but instead strings aren't translated as fallback, is this okay?