### PR TITLE
Refactor filtering Version 3

### DIFF
--- a/src/main/java/com/playonlinux/common/api/filter/Filter.java
+++ b/src/main/java/com/playonlinux/common/api/filter/Filter.java
@@ -32,6 +32,17 @@ public interface Filter<T> {
     void deleteObserver(Observer o);
 
     /**
+     * Start a filter-change transaction. While a transaction is running, the observers aren't notified.
+     */
+    void startTransaction();
+
+    /**
+     * End a filter-change transaction.
+     * @param fire Defines whether to update the observers now.
+     */
+    void endTransaction(boolean fire);
+
+    /**
      * Test the given item against the list rules defined within this list.
      *
      * @param item Item to test against the list rules.

--- a/src/main/java/com/playonlinux/common/api/filter/Filter.java
+++ b/src/main/java/com/playonlinux/common/api/filter/Filter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.common.api.filter;
+
+import java.util.Observer;
+
+/**
+ * Defines how a list (used in filterables) should look and behave like.
+ *
+ * @param <T> Type of the item stored within the filterable list.
+ */
+public interface Filter<T> {
+
+    void addObserver(Observer o);
+
+    void deleteObserver(Observer o);
+
+    /**
+     * Test the given item against the list rules defined within this list.
+     *
+     * @param item Item to test against the list rules.
+     * @return {@code true} if the given item matches the list rules, {@code false} otherwise.
+     */
+    boolean apply(T item);
+
+}

--- a/src/main/java/com/playonlinux/common/api/filter/Filterable.java
+++ b/src/main/java/com/playonlinux/common/api/filter/Filterable.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.common.api.filter;
+
+import com.playonlinux.common.api.list.ObservableList;
+
+import java.util.List;
+
+/**
+ * Defines how a filterable list of items should look and behave like.
+ *
+ * @param <T> Type of the item stored within this filterable list.
+ */
+public interface Filterable<T> extends ObservableList<T> {
+
+    /**
+     * Get an iterable with the items of this filterable that match the given list.
+     *
+     * @param filter The list to test the items against.
+     * @return An iterable over all items within this filterable that matched the given list.
+     */
+    List<T> getFiltered(Filter<T> filter);
+
+}

--- a/src/main/java/com/playonlinux/common/api/list/ObservableList.java
+++ b/src/main/java/com/playonlinux/common/api/list/ObservableList.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.common.api.list;
+
+import java.util.Observer;
+
+/**
+ * Defines how a list which can be observed for changes should look and behave like.
+ *
+ * @param <T>
+ */
+public interface ObservableList<T> extends Iterable<T> {
+
+    void addObserver(Observer o);
+
+    void deleteObserver(Observer o);
+
+    /**
+     * Get an array containing all items within this observable list.
+     *
+     * @return An array of items contained within the list.
+     */
+    T[] toArray();
+
+}

--- a/src/main/java/com/playonlinux/common/api/list/ObservableList.java
+++ b/src/main/java/com/playonlinux/common/api/list/ObservableList.java
@@ -18,6 +18,8 @@
 
 package com.playonlinux.common.api.list;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Observer;
 
 /**
@@ -30,6 +32,8 @@ public interface ObservableList<T> extends Iterable<T> {
     void addObserver(Observer o);
 
     void deleteObserver(Observer o);
+
+    int size();
 
     /**
      * Get an array containing all items within this observable list.

--- a/src/main/java/com/playonlinux/common/api/services/RemoteAvailableInstallers.java
+++ b/src/main/java/com/playonlinux/common/api/services/RemoteAvailableInstallers.java
@@ -18,24 +18,20 @@
 
 package com.playonlinux.common.api.services;
 
+import com.playonlinux.common.api.filter.Filterable;
 import com.playonlinux.common.dto.ui.CenterCategoryDTO;
 import com.playonlinux.common.dto.ui.CenterItemDTO;
 
 import java.util.List;
-import java.util.Observer;
 
-public interface RemoteAvailableInstallers extends Iterable<CenterItemDTO> {
-    void addObserver(Observer o);
-
-    void deleteObserver(Observer o);
+public interface RemoteAvailableInstallers extends Filterable<CenterItemDTO> {
 
     boolean isUpdating();
 
     boolean hasFailed();
 
-    List<CenterItemDTO> getAllCenterItems();
-
-    List<CenterCategoryDTO> getAllCategories();
+    List<CenterCategoryDTO> getCategories();
 
     void refresh();
+
 }

--- a/src/main/java/com/playonlinux/common/filter/CenterItemFilter.java
+++ b/src/main/java/com/playonlinux/common/filter/CenterItemFilter.java
@@ -21,6 +21,8 @@ package com.playonlinux.common.filter;
 import com.playonlinux.common.api.filter.Filter;
 import com.playonlinux.common.dto.ui.CenterItemDTO;
 import com.playonlinux.common.dto.web.ScriptDTO;
+import javafx.application.Platform;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Observable;
 
@@ -29,20 +31,21 @@ import java.util.Observable;
  */
 public class CenterItemFilter extends Observable implements Filter<CenterItemDTO> {
 
+    private boolean transaction = false;
+
     private String title = null;
     private String category = null;
     private boolean showTesting = false;
     private boolean showNoCd = false;
     private boolean showCommercial = true;
 
-
     public String getTitle() {
         return title;
     }
 
     public void setTitle(String title) {
-        this.title = title;
-        this.notifyObservers();
+        this.title = title.toLowerCase();
+        this.fireUpdate();
     }
 
     public String getCategory() {
@@ -51,7 +54,7 @@ public class CenterItemFilter extends Observable implements Filter<CenterItemDTO
 
     public void setCategory(String category) {
         this.category = category;
-        this.notifyObservers();
+        this.fireUpdate();
     }
 
     public boolean isShowTesting() {
@@ -60,7 +63,7 @@ public class CenterItemFilter extends Observable implements Filter<CenterItemDTO
 
     public void setShowTesting(boolean showTesting) {
         this.showTesting = showTesting;
-        this.notifyObservers();
+        this.fireUpdate();
     }
 
     public boolean isShowNoCd() {
@@ -69,7 +72,7 @@ public class CenterItemFilter extends Observable implements Filter<CenterItemDTO
 
     public void setShowNoCd(boolean showNoCd) {
         this.showNoCd = showNoCd;
-        this.notifyObservers();
+        this.fireUpdate();
     }
 
     public boolean isShowCommercial() {
@@ -78,14 +81,13 @@ public class CenterItemFilter extends Observable implements Filter<CenterItemDTO
 
     public void setShowCommercial(boolean showCommercial) {
         this.showCommercial = showCommercial;
-        this.notifyObservers();
+        this.fireUpdate();
     }
-
 
     @Override
     public boolean apply(CenterItemDTO item) {
-        if(title != null){
-            if(!item.getName().contains(title)) {
+        if(StringUtils.isNotBlank(title)){
+            if(!item.getName().toLowerCase().contains(title)) {
                 return false;
             }
         }else if(category != null && item.getCategoryName() != category) {
@@ -103,9 +105,26 @@ public class CenterItemFilter extends Observable implements Filter<CenterItemDTO
     }
 
 
+
+
+    @Override
+    public void startTransaction() {
+        transaction = true;
+    }
+
+    @Override
+    public void endTransaction(boolean fire) {
+        transaction = false;
+        if(fire){
+            this.fireUpdate();
+        }
+    }
+
     private void fireUpdate() {
-        this.setChanged();
-        this.notifyObservers();
+        if(!transaction){
+            this.setChanged();
+            this.notifyObservers();
+        }
     }
 
 }

--- a/src/main/java/com/playonlinux/common/filter/CenterItemFilter.java
+++ b/src/main/java/com/playonlinux/common/filter/CenterItemFilter.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.common.filter;
+
+import com.playonlinux.common.api.filter.Filter;
+import com.playonlinux.common.dto.ui.CenterItemDTO;
+import com.playonlinux.common.dto.web.ScriptDTO;
+
+import java.util.Observable;
+
+/**
+ * Filter implementation for CenterItems
+ */
+public class CenterItemFilter extends Observable implements Filter<CenterItemDTO> {
+
+    private String title = null;
+    private String category = null;
+    private boolean showTesting = false;
+    private boolean showNoCd = false;
+    private boolean showCommercial = true;
+
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+        this.notifyObservers();
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+        this.notifyObservers();
+    }
+
+    public boolean isShowTesting() {
+        return showTesting;
+    }
+
+    public void setShowTesting(boolean showTesting) {
+        this.showTesting = showTesting;
+        this.notifyObservers();
+    }
+
+    public boolean isShowNoCd() {
+        return showNoCd;
+    }
+
+    public void setShowNoCd(boolean showNoCd) {
+        this.showNoCd = showNoCd;
+        this.notifyObservers();
+    }
+
+    public boolean isShowCommercial() {
+        return showCommercial;
+    }
+
+    public void setShowCommercial(boolean showCommercial) {
+        this.showCommercial = showCommercial;
+        this.notifyObservers();
+    }
+
+
+    @Override
+    public boolean apply(CenterItemDTO item) {
+        if (category != null && item.getCategoryName() != category) {
+            return false;
+        }
+        if (title != null && !item.getName().contains(title)) {
+            return false;
+        }
+
+        if (item.isTesting() && !showTesting) {
+            return false;
+        }
+        if (item.isRequiresNoCd() && !showNoCd) {
+            return false;
+        }
+        return !(item.isCommercial() && !showCommercial);
+
+    }
+
+
+    private void fireUpdate() {
+        this.setChanged();
+        this.notifyObservers();
+    }
+
+}

--- a/src/main/java/com/playonlinux/common/filter/CenterItemFilter.java
+++ b/src/main/java/com/playonlinux/common/filter/CenterItemFilter.java
@@ -84,10 +84,11 @@ public class CenterItemFilter extends Observable implements Filter<CenterItemDTO
 
     @Override
     public boolean apply(CenterItemDTO item) {
-        if (category != null && item.getCategoryName() != category) {
-            return false;
-        }
-        if (title != null && !item.getName().contains(title)) {
+        if(title != null){
+            if(!item.getName().contains(title)) {
+                return false;
+            }
+        }else if(category != null && item.getCategoryName() != category) {
             return false;
         }
 

--- a/src/main/java/com/playonlinux/common/list/FilterPromise.java
+++ b/src/main/java/com/playonlinux/common/list/FilterPromise.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.common.list;
+
+import com.playonlinux.common.api.filter.Filter;
+import com.playonlinux.common.api.filter.Filterable;
+
+import java.util.*;
+
+/**
+ * An observable,filterable list whose source itself is a filterable list, accessed with the given filter.
+ *
+ * @param <T> The type of the items within the list.
+ */
+public class FilterPromise<T> extends Observable implements Filterable<T>, Observer {
+
+    private Filterable<T> source;
+    private Filter<T> filter;
+    private List<T> cache = null;
+
+    public Filterable<T> getSource() {
+        return source;
+    }
+
+    public Filter<T> getFilter() {
+        return filter;
+    }
+
+
+    public FilterPromise(Filterable<T> source, Filter<T> filter) {
+        this.source = source;
+        this.filter = filter;
+        source.addObserver(this);
+        filter.addObserver(this);
+    }
+
+
+    @Override
+    public Iterator<T> iterator() {
+        updateCache();
+        return cache.iterator();
+    }
+
+    @Override
+    public T[] toArray() {
+        updateCache();
+        return (T[]) cache.toArray();
+    }
+
+    @Override
+    public List<T> getFiltered(Filter<T> filter) {
+        updateCache();
+        return new ArrayList<>(cache);
+    }
+
+
+    @Override
+    public void update(Observable observable, Object o) {
+        cache = null;
+        this.setChanged();
+        this.notifyObservers();
+    }
+
+    private void updateCache() {
+        if (cache == null) {
+            this.cache = new ArrayList<>(source.getFiltered(filter));
+        }
+    }
+
+}

--- a/src/main/java/com/playonlinux/common/list/FilterPromise.java
+++ b/src/main/java/com/playonlinux/common/list/FilterPromise.java
@@ -58,6 +58,12 @@ public class FilterPromise<T> extends Observable implements Filterable<T>, Obser
     }
 
     @Override
+    public int size() {
+        updateCache();
+        return cache.size();
+    }
+
+    @Override
     public T[] toArray() {
         updateCache();
         return (T[]) cache.toArray();

--- a/src/main/java/com/playonlinux/common/list/FilterableList.java
+++ b/src/main/java/com/playonlinux/common/list/FilterableList.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.common.list;
+
+import com.playonlinux.common.api.filter.Filter;
+import com.playonlinux.common.api.filter.Filterable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FilterableList<T> extends ObservableArrayList<T> implements Filterable<T> {
+
+    @Override
+    public List<T> getFiltered(Filter<T> filter) {
+        List<T> filtered = new ArrayList<>();
+        for (T item : this) {
+            if (filter.apply(item)) {
+                filtered.add(item);
+            }
+        }
+        return filtered;
+    }
+
+}

--- a/src/main/java/com/playonlinux/common/list/ObservableArrayList.java
+++ b/src/main/java/com/playonlinux/common/list/ObservableArrayList.java
@@ -18,9 +18,12 @@
 
 package com.playonlinux.common.list;
 
-import com.sun.istack.internal.NotNull;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Observable;
 
 /**
  * ArrayList that can be observed for changes.

--- a/src/main/java/com/playonlinux/common/list/ObservableArrayList.java
+++ b/src/main/java/com/playonlinux/common/list/ObservableArrayList.java
@@ -51,6 +51,12 @@ public class ObservableArrayList<T> extends Observable implements List<T>, com.p
         return list.iterator();
     }
 
+    public void swapContents(Collection<T> newContent) {
+        list.clear();
+        list.addAll(newContent);
+        this.fireUpdate();
+    }
+
     @Override
     public T[] toArray() {
         return (T[]) list.toArray();

--- a/src/main/java/com/playonlinux/common/list/ObservableArrayList.java
+++ b/src/main/java/com/playonlinux/common/list/ObservableArrayList.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.common.list;
+
+import com.sun.istack.internal.NotNull;
+
+import java.util.*;
+
+/**
+ * ArrayList that can be observed for changes.
+ *
+ * @param <T> Type of the items within this list.
+ */
+public class ObservableArrayList<T> extends Observable implements List<T>, com.playonlinux.common.api.list.ObservableList<T> {
+
+    private List<T> list = new ArrayList<>();
+
+    @Override
+    public int size() {
+        return list.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return list.contains(o);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return list.iterator();
+    }
+
+    @Override
+    public T[] toArray() {
+        return (T[]) list.toArray();
+    }
+
+    @Override
+    public <T1> T1[] toArray(T1[] t1s) {
+        return list.toArray(t1s);
+    }
+
+    @Override
+    public boolean add(T t) {
+        boolean changed = list.add(t);
+        if (changed) {
+            this.fireUpdate();
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        boolean changed = list.remove(o);
+        if (changed) {
+            this.fireUpdate();
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> collection) {
+        return list.containsAll(collection);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> collection) {
+        boolean changed = list.addAll(collection);
+        if (changed) {
+            this.fireUpdate();
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean addAll(int i, Collection<? extends T> collection) {
+        boolean changed = list.addAll(i, collection);
+        if (changed) {
+            this.fireUpdate();
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> collection) {
+        boolean changed = list.removeAll(collection);
+        if (changed) {
+            this.fireUpdate();
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> collection) {
+        boolean changed = list.retainAll(collection);
+        if (changed) {
+            this.fireUpdate();
+        }
+        return changed;
+    }
+
+    @Override
+    public void clear() {
+        list.clear();
+    }
+
+    @Override
+    public T get(int i) {
+        return list.get(i);
+    }
+
+    @Override
+    public T set(int i, T t) {
+        T oldItem = list.set(i, t);
+        this.fireUpdate();
+        return oldItem;
+    }
+
+    @Override
+    public void add(int i, T t) {
+        list.add(i, t);
+        this.fireUpdate();
+    }
+
+    @Override
+    public T remove(int i) {
+        T oldItem = list.remove(i);
+        this.fireUpdate();
+        return oldItem;
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return list.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return list.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<T> listIterator() {
+        return list.listIterator();
+    }
+
+    @Override
+    public ListIterator<T> listIterator(int i) {
+        return list.listIterator(i);
+    }
+
+    @Override
+    public List<T> subList(int i, int i1) {
+        return list.subList(i, i1);
+    }
+
+
+    private void fireUpdate() {
+        this.setChanged();
+        this.notifyObservers();
+    }
+
+}

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/center/CategoryView.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/center/CategoryView.java
@@ -72,9 +72,7 @@ public class CategoryView extends VBox implements Observer {
 
     private void fireCategorySelection(String categoryName){
         for(CategorySelectionObserver o : observers){
-            try{
-                o.update(this, categoryName);
-            }catch(Exception ex){}
+            o.update(this, categoryName);
         }
     }
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/center/CategoryView.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/center/CategoryView.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.ui.impl.javafx.mainwindow.center;
+
+import com.playonlinux.common.api.list.ObservableList;
+import com.playonlinux.common.dto.ui.CenterCategoryDTO;
+import com.playonlinux.common.dto.web.CategoryDTO;
+import com.playonlinux.ui.impl.javafx.mainwindow.LeftBarTitle;
+import com.playonlinux.ui.impl.javafx.mainwindow.LeftButton;
+import com.playonlinux.ui.impl.javafx.mainwindow.LeftSpacer;
+import javafx.scene.layout.VBox;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Observable;
+import java.util.Observer;
+
+import static com.playonlinux.domain.Localisation.translate;
+
+public class CategoryView extends VBox implements Observer {
+
+    private ObservableList<CenterCategoryDTO> categories;
+    private List<CategorySelectionObserver> observers = new ArrayList<>();
+
+    public CategoryView (ObservableList<CenterCategoryDTO> categoryList){
+        this.categories = categoryList;
+        categoryList.addObserver(this);
+        this.update(null, null);
+    }
+
+
+    @Override
+    public void update(Observable observable, Object o) {
+        this.getChildren().clear();
+        this.getChildren().addAll(new LeftBarTitle(translate("Category")));
+
+        if(categories.size() > 0) {
+            for (CenterCategoryDTO category : categories) {
+                LeftButton categoryButton = new LeftButton(category.getIconName(), category.getName());
+                this.getChildren().add(categoryButton);
+                categoryButton.setOnMouseClicked(event -> {
+                    this.fireCategorySelection(categoryButton.getName());
+                });
+            }
+        }
+    }
+
+
+    public void addObserver(CategorySelectionObserver o){
+        this.observers.add(o);
+    }
+
+    public void deleteObserver(CategorySelectionObserver o){
+        this.observers.remove(o);
+    }
+
+    private void fireCategorySelection(String categoryName){
+        for(CategorySelectionObserver o : observers){
+            try{
+                o.update(this, categoryName);
+            }catch(Exception ex){}
+        }
+    }
+
+
+    public interface CategorySelectionObserver {
+
+        void update(CategoryView categoryView, String category);
+
+    }
+
+
+}

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/center/CategoryView.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/center/CategoryView.java
@@ -20,10 +20,8 @@ package com.playonlinux.ui.impl.javafx.mainwindow.center;
 
 import com.playonlinux.common.api.list.ObservableList;
 import com.playonlinux.common.dto.ui.CenterCategoryDTO;
-import com.playonlinux.common.dto.web.CategoryDTO;
 import com.playonlinux.ui.impl.javafx.mainwindow.LeftBarTitle;
 import com.playonlinux.ui.impl.javafx.mainwindow.LeftButton;
-import com.playonlinux.ui.impl.javafx.mainwindow.LeftSpacer;
 import javafx.scene.layout.VBox;
 
 import java.util.ArrayList;
@@ -33,12 +31,12 @@ import java.util.Observer;
 
 import static com.playonlinux.domain.Localisation.translate;
 
-public class CategoryView extends VBox implements Observer {
+public final class CategoryView extends VBox implements Observer {
 
     private ObservableList<CenterCategoryDTO> categories;
     private List<CategorySelectionObserver> observers = new ArrayList<>();
 
-    public CategoryView (ObservableList<CenterCategoryDTO> categoryList){
+    public CategoryView(ObservableList<CenterCategoryDTO> categoryList) {
         this.categories = categoryList;
         categoryList.addObserver(this);
         this.update(null, null);
@@ -50,7 +48,7 @@ public class CategoryView extends VBox implements Observer {
         this.getChildren().clear();
         this.getChildren().addAll(new LeftBarTitle(translate("Category")));
 
-        if(categories.size() > 0) {
+        if (categories.size() > 0) {
             for (CenterCategoryDTO category : categories) {
                 LeftButton categoryButton = new LeftButton(category.getIconName(), category.getName());
                 this.getChildren().add(categoryButton);
@@ -62,16 +60,16 @@ public class CategoryView extends VBox implements Observer {
     }
 
 
-    public void addObserver(CategorySelectionObserver o){
+    public void addObserver(CategorySelectionObserver o) {
         this.observers.add(o);
     }
 
-    public void deleteObserver(CategorySelectionObserver o){
+    public void deleteObserver(CategorySelectionObserver o) {
         this.observers.remove(o);
     }
 
-    private void fireCategorySelection(String categoryName){
-        for(CategorySelectionObserver o : observers){
+    private void fireCategorySelection(String categoryName) {
+        for (CategorySelectionObserver o : observers) {
             o.update(this, categoryName);
         }
     }

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/center/ViewApps.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/center/ViewApps.java
@@ -43,7 +43,7 @@ public class ViewApps extends HBox implements Observer {
     private VBox failurePanel;
     private Button retryButton;
     private ObservableArrayList<CenterCategoryDTO> categories;
-    private FilterPromise<CenterItemDTO> centerItems = null;
+    private FilterPromise<CenterItemDTO> centerItems;
     private final SimpleIconListWidget availableInstallerListWidget;
 
     private final EventHandlerCenter eventHandlerCenter;
@@ -68,7 +68,7 @@ public class ViewApps extends HBox implements Observer {
         this.initFailure();
 
         categories = new ObservableArrayList<>();
-        centerItems = new FilterPromise<CenterItemDTO>(eventHandlerCenter.getRemoteAvailableInstallers(), this.filter);
+        centerItems = new FilterPromise<>(eventHandlerCenter.getRemoteAvailableInstallers(), this.filter);
 
         this.drawSideBar();
         this.showWait();


### PR DESCRIPTION
Refactored the process of filtering, which then can easily be applied for the other sections (Shortcuts, Engine-Versions, ...).
We should talk about how and where to handle the flag-filtering (testing / NoCd / Commercial) - which I left unimplemented for now.

__Abstract__:
`Filter<T>` and `Filterable<T>` are both observable. Whenever something changes (e.g. filter-parameters), the observers are notified.
I combined both within `FilterPromise<T>`, which listens to Filter and Filterable and updates, after either one of them changed - directly providing the new filtered list.
I outsourced the list of categories into an own widget (`CategoryView`) to avoid unnecessary repaints and potential memory leaks. The CategoryView is passed an `ObservableList<T>` which fires an update after its list has changed and therefore causing the CategoryView to repaint the list of CategoryButtons.
The CategoryView is rendered nearly the same as before, however I'm not sure if that's not a memory-leak - since the observers of the CategoryButtons are never removed. We should probably have an eye on that one.