### PR TITLE
Main window search

### DIFF
--- a/src/main/java/com/playonlinux/common/api/services/InstalledApplications.java
+++ b/src/main/java/com/playonlinux/common/api/services/InstalledApplications.java
@@ -18,10 +18,11 @@
 
 package com.playonlinux.common.api.services;
 
+import com.playonlinux.common.api.filter.Filterable;
 import com.playonlinux.common.dto.ui.ShortcutDTO;
 
 import java.util.Observer;
 
-public interface InstalledApplications extends Iterable<ShortcutDTO> {
+public interface InstalledApplications extends Filterable<ShortcutDTO>, Iterable<ShortcutDTO> {
     void addObserver(Observer o);
 }

--- a/src/main/java/com/playonlinux/common/api/services/InstalledApplications.java
+++ b/src/main/java/com/playonlinux/common/api/services/InstalledApplications.java
@@ -24,5 +24,6 @@ import com.playonlinux.common.dto.ui.ShortcutDTO;
 import java.util.Observer;
 
 public interface InstalledApplications extends Filterable<ShortcutDTO>, Iterable<ShortcutDTO> {
+
     void addObserver(Observer o);
 }

--- a/src/main/java/com/playonlinux/common/api/services/InstalledApplications.java
+++ b/src/main/java/com/playonlinux/common/api/services/InstalledApplications.java
@@ -19,11 +19,11 @@
 package com.playonlinux.common.api.services;
 
 import com.playonlinux.common.api.filter.Filterable;
-import com.playonlinux.common.dto.ui.ShortcutDTO;
+import com.playonlinux.common.dto.ui.InstalledApplicationDTO;
 
 import java.util.Observer;
 
-public interface InstalledApplications extends Filterable<ShortcutDTO>, Iterable<ShortcutDTO> {
+public interface InstalledApplications extends Filterable<InstalledApplicationDTO>, Iterable<InstalledApplicationDTO> {
 
     void addObserver(Observer o);
 }

--- a/src/main/java/com/playonlinux/common/dto/ui/InstalledApplicationDTO.java
+++ b/src/main/java/com/playonlinux/common/dto/ui/InstalledApplicationDTO.java
@@ -22,11 +22,11 @@ import com.playonlinux.common.api.dto.AbstractDTO;
 
 import java.net.URL;
 
-public class ShortcutDTO implements AbstractDTO {
+public class InstalledApplicationDTO implements AbstractDTO {
     private final URL icon;
     private final String name;
 
-    public ShortcutDTO(Builder builder) {
+    public InstalledApplicationDTO(Builder builder) {
         this.name = builder.name;
         this.icon = builder.icon;
     }
@@ -53,8 +53,8 @@ public class ShortcutDTO implements AbstractDTO {
             return this;
         }
 
-        public ShortcutDTO build() {
-            return new ShortcutDTO(this);
+        public InstalledApplicationDTO build() {
+            return new InstalledApplicationDTO(this);
         }
     }
 }

--- a/src/main/java/com/playonlinux/common/filter/InstalledApplicationFilter.java
+++ b/src/main/java/com/playonlinux/common/filter/InstalledApplicationFilter.java
@@ -47,16 +47,7 @@ public class InstalledApplicationFilter extends Observable implements Filter<Ins
 
     @Override
     public boolean apply(InstalledApplicationDTO item) {
-        if(StringUtils.isBlank(name)) {
-            return false;
-        }
-
-        if(StringUtils.isNotBlank(name)){
-            if(!item.getName().toLowerCase().contains(name)) {
-                return false;
-            }
-        }
-        return false;
+        return !StringUtils.isNotBlank(name) || item.getName().toLowerCase().contains(name);
     }
 
     private void fireUpdate() {

--- a/src/main/java/com/playonlinux/common/filter/InstalledApplicationFilter.java
+++ b/src/main/java/com/playonlinux/common/filter/InstalledApplicationFilter.java
@@ -47,6 +47,7 @@ public class InstalledApplicationFilter extends Observable implements Filter<Ins
 
     @Override
     public boolean apply(InstalledApplicationDTO item) {
+        // We want to return the whole list for empty search string. Otherwise compare strings.
         return !StringUtils.isNotBlank(name) || item.getName().toLowerCase().contains(name);
     }
 

--- a/src/main/java/com/playonlinux/common/filter/InstalledApplicationFilter.java
+++ b/src/main/java/com/playonlinux/common/filter/InstalledApplicationFilter.java
@@ -18,18 +18,21 @@
 package com.playonlinux.common.filter;
 
 import com.playonlinux.common.api.filter.Filter;
-import com.playonlinux.common.dto.ui.ShortcutDTO;
+import com.playonlinux.common.dto.ui.InstalledApplicationDTO;
 import org.apache.commons.lang.StringUtils;
 
 import java.net.URL;
 import java.util.Observable;
 
-public class InstalledApplicationFilter extends Observable implements Filter<ShortcutDTO> {
+/**
+ * Filter for installed applications in the MainWindow
+ */
+public class InstalledApplicationFilter extends Observable implements Filter<InstalledApplicationDTO> {
 
     private boolean transaction = false;
 
     private String name = "";
-    private URL icon;
+    private URL icon = null;
 
     @Override
     public void startTransaction() { transaction = true; }
@@ -42,15 +45,8 @@ public class InstalledApplicationFilter extends Observable implements Filter<Sho
         }
     }
 
-    private void fireUpdate() {
-        if(!transaction){
-            this.setChanged();
-            this.notifyObservers();
-        }
-    }
-
     @Override
-    public boolean apply(ShortcutDTO item) {
+    public boolean apply(InstalledApplicationDTO item) {
         if(StringUtils.isBlank(name)) {
             return false;
         }
@@ -63,12 +59,20 @@ public class InstalledApplicationFilter extends Observable implements Filter<Sho
         return false;
     }
 
+    private void fireUpdate() {
+        if(!transaction){
+            this.setChanged();
+            this.notifyObservers();
+        }
+    }
+
     public String getName() {
         return name;
     }
 
     public void setName(String name) {
-        this.name = name;
+        this.name = name.toLowerCase();
+        fireUpdate();
     }
 
     public URL getIcon() {
@@ -77,5 +81,6 @@ public class InstalledApplicationFilter extends Observable implements Filter<Sho
 
     public void setIcon(URL icon) {
         this.icon = icon;
+        fireUpdate();
     }
 }

--- a/src/main/java/com/playonlinux/common/filter/InstalledApplicationFilter.java
+++ b/src/main/java/com/playonlinux/common/filter/InstalledApplicationFilter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package com.playonlinux.common.filter;
+
+import com.playonlinux.common.api.filter.Filter;
+import com.playonlinux.common.dto.ui.ShortcutDTO;
+import org.apache.commons.lang.StringUtils;
+
+import java.net.URL;
+import java.util.Observable;
+
+public class InstalledApplicationFilter extends Observable implements Filter<ShortcutDTO> {
+
+    private boolean transaction = false;
+
+    private String name = "";
+    private URL icon;
+
+    @Override
+    public void startTransaction() { transaction = true; }
+
+    @Override
+    public void endTransaction(boolean fire) {
+        transaction = false;
+        if(fire){
+            this.fireUpdate();
+        }
+    }
+
+    private void fireUpdate() {
+        if(!transaction){
+            this.setChanged();
+            this.notifyObservers();
+        }
+    }
+
+    @Override
+    public boolean apply(ShortcutDTO item) {
+        if(StringUtils.isBlank(name)) {
+            return false;
+        }
+
+        if(StringUtils.isNotBlank(name)){
+            if(!item.getName().toLowerCase().contains(name)) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public URL getIcon() {
+        return icon;
+    }
+
+    public void setIcon(URL icon) {
+        this.icon = icon;
+    }
+}

--- a/src/main/java/com/playonlinux/common/services/InstalledApplicationsPlayOnLinuxImplementation.java
+++ b/src/main/java/com/playonlinux/common/services/InstalledApplicationsPlayOnLinuxImplementation.java
@@ -33,7 +33,6 @@ import com.playonlinux.utils.ObservableDirectoryFiles;
 import java.io.File;
 import java.net.URL;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Scan
 public class InstalledApplicationsPlayOnLinuxImplementation extends Observable implements InstalledApplications, Observer {
@@ -111,19 +110,8 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
 
     @Override
     public List<ShortcutDTO> getFiltered(Filter<ShortcutDTO> filter) {
-        List<ShortcutDTO> filtered = new ArrayList<>();
-
-
-
-        List<ShortcutDTO> copy = copyIterator(shortcutDtoIterator);
-        System.out.print(shortcutDtoIterator.hasNext());
-        System.out.print("Size: " + copy.size());
-
-        for(ShortcutDTO s : copy) {
-            System.out.print(s.getName());
-        }
-
-        filtered.addAll(copy.stream().filter(filter::apply).collect(Collectors.toList()));
+        List<ShortcutDTO> filtered = copyIterator(shortcutDtoIterator);
+        //filtered.addAll(copy.stream().filter(filter::apply).collect(Collectors.toList()));
         return filtered;
     }
 
@@ -148,4 +136,5 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
             copy.add(iter.next());
         return copy;
     }
+
 }

--- a/src/main/java/com/playonlinux/common/services/InstalledApplicationsPlayOnLinuxImplementation.java
+++ b/src/main/java/com/playonlinux/common/services/InstalledApplicationsPlayOnLinuxImplementation.java
@@ -22,7 +22,7 @@ import com.playonlinux.app.PlayOnLinuxContext;
 import com.playonlinux.common.api.filter.Filter;
 import com.playonlinux.common.api.services.BackgroundServiceManager;
 import com.playonlinux.common.api.services.InstalledApplications;
-import com.playonlinux.common.dto.ui.ShortcutDTO;
+import com.playonlinux.common.dto.ui.InstalledApplicationDTO;
 import com.playonlinux.domain.PlayOnLinuxException;
 import com.playonlinux.domain.Shortcut;
 import com.playonlinux.domain.ShortcutSet;
@@ -43,8 +43,8 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
     static BackgroundServiceManager playOnLinuxBackgroundServicesManager;
 
     ShortcutSet shortcutSet;
-    private Iterator<ShortcutDTO> shortcutDtoIterator;
-    private List<ShortcutDTO> cache = null;
+    private Iterator<InstalledApplicationDTO> shortcutDtoIterator;
+    private List<InstalledApplicationDTO> cache = null;
 
     InstalledApplicationsPlayOnLinuxImplementation() throws PlayOnLinuxException {
         File shortcutDirectory = playOnLinuxContext.makeShortcutsScriptsPath();
@@ -74,7 +74,7 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
 
     @Override
     public synchronized void update(Observable o, Object arg) {
-        shortcutDtoIterator = new Iterator<ShortcutDTO>() {
+        shortcutDtoIterator = new Iterator<InstalledApplicationDTO>() {
             volatile int i = 0;
 
             @Override
@@ -84,7 +84,7 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
             }
 
             @Override
-            public ShortcutDTO next() {
+            public InstalledApplicationDTO next() {
                 assert(arg instanceof List);
                 List<Shortcut> shortcutList = ((List<Shortcut>) arg);
                 if(i >= shortcutList.size()) {
@@ -92,7 +92,7 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
                 }
                 Shortcut shortcut = shortcutList.get(i);
                 i++;
-                return new ShortcutDTO.Builder()
+                return new InstalledApplicationDTO.Builder()
                         .withName(shortcut.getShortcutName())
                         .withIcon(shortcut.getIconPath())
                         .build();
@@ -104,13 +104,13 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
     }
 
     @Override
-    public synchronized Iterator<ShortcutDTO> iterator() {
+    public synchronized Iterator<InstalledApplicationDTO> iterator() {
         return this.shortcutDtoIterator;
     }
 
     @Override
-    public List<ShortcutDTO> getFiltered(Filter<ShortcutDTO> filter) {
-        List<ShortcutDTO> filtered = copyIterator(shortcutDtoIterator);
+    public List<InstalledApplicationDTO> getFiltered(Filter<InstalledApplicationDTO> filter) {
+        List<InstalledApplicationDTO> filtered = copyIterator(shortcutDtoIterator);
         //filtered.addAll(copy.stream().filter(filter::apply).collect(Collectors.toList()));
         return filtered;
     }
@@ -122,8 +122,8 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
     }
 
     @Override
-    public ShortcutDTO[] toArray() {
-        return cache.toArray(new ShortcutDTO[cache.size()]);
+    public InstalledApplicationDTO[] toArray() {
+        return cache.toArray(new InstalledApplicationDTO[cache.size()]);
     }
 
     private void updateCache() {

--- a/src/main/java/com/playonlinux/common/services/InstalledApplicationsPlayOnLinuxImplementation.java
+++ b/src/main/java/com/playonlinux/common/services/InstalledApplicationsPlayOnLinuxImplementation.java
@@ -19,6 +19,7 @@
 package com.playonlinux.common.services;
 
 import com.playonlinux.app.PlayOnLinuxContext;
+import com.playonlinux.common.api.filter.Filter;
 import com.playonlinux.common.api.services.BackgroundServiceManager;
 import com.playonlinux.common.api.services.InstalledApplications;
 import com.playonlinux.common.dto.ui.ShortcutDTO;
@@ -32,6 +33,7 @@ import com.playonlinux.utils.ObservableDirectoryFiles;
 import java.io.File;
 import java.net.URL;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Scan
 public class InstalledApplicationsPlayOnLinuxImplementation extends Observable implements InstalledApplications, Observer {
@@ -43,6 +45,7 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
 
     ShortcutSet shortcutSet;
     private Iterator<ShortcutDTO> shortcutDtoIterator;
+    private List<ShortcutDTO> cache = null;
 
     InstalledApplicationsPlayOnLinuxImplementation() throws PlayOnLinuxException {
         File shortcutDirectory = playOnLinuxContext.makeShortcutsScriptsPath();
@@ -106,4 +109,43 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
         return this.shortcutDtoIterator;
     }
 
+    @Override
+    public List<ShortcutDTO> getFiltered(Filter<ShortcutDTO> filter) {
+        List<ShortcutDTO> filtered = new ArrayList<>();
+
+
+
+        List<ShortcutDTO> copy = copyIterator(shortcutDtoIterator);
+        System.out.print(shortcutDtoIterator.hasNext());
+        System.out.print("Size: " + copy.size());
+
+        for(ShortcutDTO s : copy) {
+            System.out.print(s.getName());
+        }
+
+        filtered.addAll(copy.stream().filter(filter::apply).collect(Collectors.toList()));
+        return filtered;
+    }
+
+    @Override
+    public int size() {
+        updateCache();
+        return cache.size();
+    }
+
+    @Override
+    public ShortcutDTO[] toArray() {
+        return cache.toArray(new ShortcutDTO[cache.size()]);
+    }
+
+    private void updateCache() {
+
+    }
+
+    public static <T> List<T> copyIterator(Iterator<T> iter) {
+        List<T> copy = new ArrayList<T>();
+        while (iter.hasNext())
+            copy.add(iter.next());
+        return copy;
+    }
 }

--- a/src/main/java/com/playonlinux/common/services/InstalledApplicationsPlayOnLinuxImplementation.java
+++ b/src/main/java/com/playonlinux/common/services/InstalledApplicationsPlayOnLinuxImplementation.java
@@ -33,6 +33,7 @@ import com.playonlinux.utils.ObservableDirectoryFiles;
 import java.io.File;
 import java.net.URL;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Scan
 public class InstalledApplicationsPlayOnLinuxImplementation extends Observable implements InstalledApplications, Observer {
@@ -45,6 +46,7 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
     ShortcutSet shortcutSet;
     private Iterator<InstalledApplicationDTO> shortcutDtoIterator;
     private List<InstalledApplicationDTO> cache = null;
+    private List<InstalledApplicationDTO> installedApplications;
 
     InstalledApplicationsPlayOnLinuxImplementation() throws PlayOnLinuxException {
         File shortcutDirectory = playOnLinuxContext.makeShortcutsScriptsPath();
@@ -99,6 +101,7 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
             }
         };
 
+        installedApplications = copyIterator(shortcutDtoIterator);
         this.setChanged();
         this.notifyObservers();
     }
@@ -110,9 +113,7 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
 
     @Override
     public List<InstalledApplicationDTO> getFiltered(Filter<InstalledApplicationDTO> filter) {
-        List<InstalledApplicationDTO> filtered = copyIterator(shortcutDtoIterator);
-        //filtered.addAll(copy.stream().filter(filter::apply).collect(Collectors.toList()));
-        return filtered;
+        return installedApplications.stream().filter(filter::apply).collect(Collectors.toList());
     }
 
     @Override
@@ -127,13 +128,15 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
     }
 
     private void updateCache() {
-
+        if(cache == null) {
+            cache = new ArrayList<>();
+        }
     }
 
-    public static <T> List<T> copyIterator(Iterator<T> iter) {
-        List<T> copy = new ArrayList<T>();
-        while (iter.hasNext())
-            copy.add(iter.next());
+    public static <T> List<T> copyIterator(Iterator<T> iterator) {
+        List<T> copy = new ArrayList<>();
+        while (iterator.hasNext())
+            copy.add(iterator.next());
         return copy;
     }
 

--- a/src/main/java/com/playonlinux/common/services/InstalledApplicationsPlayOnLinuxImplementation.java
+++ b/src/main/java/com/playonlinux/common/services/InstalledApplicationsPlayOnLinuxImplementation.java
@@ -45,7 +45,7 @@ public class InstalledApplicationsPlayOnLinuxImplementation extends Observable i
 
     ShortcutSet shortcutSet;
     private Iterator<InstalledApplicationDTO> shortcutDtoIterator;
-    private List<InstalledApplicationDTO> cache = null;
+    private List<InstalledApplicationDTO> cache;
     private List<InstalledApplicationDTO> installedApplications;
 
     InstalledApplicationsPlayOnLinuxImplementation() throws PlayOnLinuxException {

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/apps/ViewApps.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/apps/ViewApps.java
@@ -25,13 +25,17 @@ import com.playonlinux.common.filter.CenterItemFilter;
 import com.playonlinux.common.list.FilterPromise;
 import com.playonlinux.common.list.ObservableArrayList;
 import com.playonlinux.ui.impl.javafx.common.MiniatureListWidget;
-import com.playonlinux.ui.impl.javafx.mainwindow.*;
+import com.playonlinux.ui.impl.javafx.mainwindow.LeftBarTitle;
+import com.playonlinux.ui.impl.javafx.mainwindow.LeftSideBar;
+import com.playonlinux.ui.impl.javafx.mainwindow.LeftSpacer;
+import com.playonlinux.ui.impl.javafx.mainwindow.MainWindow;
 import javafx.application.Platform;
 import javafx.geometry.Pos;
 import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.*;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.TextAlignment;
 import org.apache.commons.lang.StringUtils;
 
@@ -166,8 +170,6 @@ public class ViewApps extends HBox implements Observer {
         centerItems.addObserver(this);
         retryButton.setOnMouseClicked(event -> this.eventHandlerCenter.updateAvailableInstallers());
     }
-
-
 
     @Override
     public void update(Observable o, Object arg) {

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
@@ -24,12 +24,16 @@ import com.playonlinux.common.list.FilterPromise;
 import com.playonlinux.domain.PlayOnLinuxException;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
-import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.text.Text;
+import org.apache.commons.lang.StringUtils;
 
 import java.net.URL;
 import java.util.Observable;
@@ -70,6 +74,9 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
         System.out.print("\nUpdate");
         Platform.runLater(() -> {
             this.clear();
+            if(StringUtils.isBlank(filter.getName())) {
+                parent.getSearchBar().setText("");
+            }
             for (InstalledApplicationDTO shortcut : installedApplications) {
                 addItem(shortcut.getName(), shortcut.getIcon());
             }
@@ -80,8 +87,8 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
         rootItem.getChildren().clear();
     }
 
-    public void search(TextField searchBar) {
-        filter.setName(searchBar.getText());
+    public void search(String searchBar) {
+        filter.setName(searchBar);
         System.out.print("\nFilter: " + filter.getName());
     }
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
@@ -69,7 +69,6 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
     @Override
     public synchronized void update(Observable o, Object arg) {
         // TODO: Something is calling this method twice on startup. Could use some research
-        System.out.print("\nUpdate");
         Platform.runLater(() -> {
             this.clear();
             if(StringUtils.isBlank(filter.getName())) {
@@ -87,7 +86,6 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
 
     public void search(String searchBar) {
         filter.setName(searchBar);
-        System.out.print("\nFilter: " + filter.getName());
     }
 
     protected class ApplicationItem extends GridPane {

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
@@ -24,10 +24,7 @@ import com.playonlinux.common.list.FilterPromise;
 import com.playonlinux.domain.PlayOnLinuxException;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
-import javafx.scene.control.Button;
-import javafx.scene.control.ContentDisplay;
-import javafx.scene.control.TreeItem;
-import javafx.scene.control.TreeView;
+import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.ColumnConstraints;
@@ -40,13 +37,12 @@ import java.util.Observer;
 
 import static com.playonlinux.domain.Localisation.translate;
 
-
 class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationItem> implements Observer {
     private final TreeItem<ApplicationItem> rootItem;
     private final ViewLibrary parent;
 
     private EventHandlerMyApps eventHandlerMyApps;
-    private FilterPromise<InstalledApplicationDTO> applications;
+    private FilterPromise<InstalledApplicationDTO> installedApplications;
     private InstalledApplicationFilter filter = new InstalledApplicationFilter();
 
     public ApplicationListWidget(ViewLibrary parent) {
@@ -56,11 +52,11 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
         this.setRoot(rootItem);
         this.setShowRoot(false);
         try {
-            applications = new FilterPromise<>(eventHandlerMyApps.getInstalledApplications(), this.filter);
+            installedApplications = new FilterPromise<>(eventHandlerMyApps.getInstalledApplications(), this.filter);
         } catch (PlayOnLinuxException e) {
             e.printStackTrace();
         }
-        applications.addObserver(this);
+        installedApplications.addObserver(this);
     }
 
     public void addItem(String shortcutName, URL iconPath) {
@@ -70,11 +66,11 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
 
     @Override
     public synchronized void update(Observable o, Object arg) {
-        // TODO: Something is calling this method twice on startup
+        // TODO: Something is calling this method twice on startup. Could use some research
         System.out.print("\nUpdate");
         Platform.runLater(() -> {
             this.clear();
-            for (InstalledApplicationDTO shortcut : applications) {
+            for (InstalledApplicationDTO shortcut : installedApplications) {
                 addItem(shortcut.getName(), shortcut.getIcon());
             }
         });
@@ -84,8 +80,8 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
         rootItem.getChildren().clear();
     }
 
-    public void search(String searchText) {
-        filter.setName(searchText);
+    public void search(TextField searchBar) {
+        filter.setName(searchBar.getText());
         System.out.print("\nFilter: " + filter.getName());
     }
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
@@ -24,16 +24,14 @@ import com.playonlinux.common.list.FilterPromise;
 import com.playonlinux.domain.PlayOnLinuxException;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
-import javafx.scene.control.Button;
-import javafx.scene.control.ContentDisplay;
-import javafx.scene.control.TreeItem;
-import javafx.scene.control.TreeView;
+import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.text.Text;
 import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
 
 import java.net.URL;
 import java.util.Observable;
@@ -42,11 +40,12 @@ import java.util.Observer;
 import static com.playonlinux.domain.Localisation.translate;
 
 class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationItem> implements Observer {
+
     private final TreeItem<ApplicationItem> rootItem;
     private final ViewLibrary parent;
-
-    private FilterPromise<InstalledApplicationDTO> installedApplications;
     private final InstalledApplicationFilter filter = new InstalledApplicationFilter();
+    private FilterPromise<InstalledApplicationDTO> installedApplications;
+    private Logger logger = Logger.getLogger(this.getClass());
 
     public ApplicationListWidget(ViewLibrary parent) {
         this.parent = parent;
@@ -56,7 +55,11 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
         try {
             installedApplications = new FilterPromise<>(this.parent.getEventHandler().getInstalledApplications(), this.filter);
         } catch (PlayOnLinuxException e) {
-            e.printStackTrace();
+            Alert alert = new Alert(Alert.AlertType.ERROR);
+            alert.setTitle(translate("Error while trying to fetch installed applications."));
+            alert.setContentText(String.format("The error was: %s", e));
+            alert.show();
+            logger.error(e);
         }
         installedApplications.addObserver(this);
     }

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
@@ -18,7 +18,7 @@
 
 package com.playonlinux.ui.impl.javafx.mainwindow.library;
 
-import com.playonlinux.common.dto.ui.ShortcutDTO;
+import com.playonlinux.common.dto.ui.InstalledApplicationDTO;
 import com.playonlinux.common.filter.InstalledApplicationFilter;
 import com.playonlinux.common.list.FilterPromise;
 import com.playonlinux.domain.PlayOnLinuxException;
@@ -45,10 +45,9 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
     private final TreeItem<ApplicationItem> rootItem;
     private final ViewLibrary parent;
 
-
     private EventHandlerMyApps eventHandlerMyApps;
+    private FilterPromise<InstalledApplicationDTO> applications;
     private InstalledApplicationFilter filter = new InstalledApplicationFilter();
-    private FilterPromise<ShortcutDTO> applications;
 
     public ApplicationListWidget(ViewLibrary parent) {
         eventHandlerMyApps = new EventHandlerMyApps();
@@ -71,10 +70,11 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
 
     @Override
     public synchronized void update(Observable o, Object arg) {
-        System.out.print("\n Update apps");
+        // TODO: Something is calling this method twice on startup
+        System.out.print("\nUpdate");
         Platform.runLater(() -> {
             this.clear();
-            for (ShortcutDTO shortcut : applications) {
+            for (InstalledApplicationDTO shortcut : applications) {
                 addItem(shortcut.getName(), shortcut.getIcon());
             }
         });
@@ -86,6 +86,7 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
 
     public void search(String searchText) {
         filter.setName(searchText);
+        System.out.print("\nFilter: " + filter.getName());
     }
 
     protected class ApplicationItem extends GridPane {

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ApplicationListWidget.java
@@ -45,18 +45,16 @@ class ApplicationListWidget extends TreeView<ApplicationListWidget.ApplicationIt
     private final TreeItem<ApplicationItem> rootItem;
     private final ViewLibrary parent;
 
-    private EventHandlerMyApps eventHandlerMyApps;
     private FilterPromise<InstalledApplicationDTO> installedApplications;
-    private InstalledApplicationFilter filter = new InstalledApplicationFilter();
+    private final InstalledApplicationFilter filter = new InstalledApplicationFilter();
 
     public ApplicationListWidget(ViewLibrary parent) {
-        eventHandlerMyApps = new EventHandlerMyApps();
         this.parent = parent;
         this.rootItem = new TreeItem<>();
         this.setRoot(rootItem);
         this.setShowRoot(false);
         try {
-            installedApplications = new FilterPromise<>(eventHandlerMyApps.getInstalledApplications(), this.filter);
+            installedApplications = new FilterPromise<>(this.parent.getEventHandler().getInstalledApplications(), this.filter);
         } catch (PlayOnLinuxException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
@@ -52,8 +52,6 @@ public class ViewLibrary extends HBox {
     private void drawContent() {
         applicationListWidget = new ApplicationListWidget(this);
         applicationListWidget.getStyleClass().add("rightPane");
-
-
         this.getChildren().add(applicationListWidget);
     }
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
@@ -39,7 +39,6 @@ public class ViewLibrary extends HBox {
     private ApplicationListWidget applicationListWidget;
     private final EventHandlerMyApps eventHandlerMyApps;
 
-
     public ViewLibrary(MainWindow parent) {
         this.parent = parent;
         this.getStyleClass().add("mainWindowScene");
@@ -62,7 +61,7 @@ public class ViewLibrary extends HBox {
 
         TextField searchBar = new TextField();
         searchBar.setOnKeyReleased(event -> {
-            applicationListWidget.search(event.getText());
+            applicationListWidget.search(searchBar);
         });
 
         this.runScript = new LeftButton("/com/playonlinux/ui/impl/javafx/mainwindow/library/script.png", "Run a script");

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
@@ -38,6 +38,7 @@ public class ViewLibrary extends HBox {
     private Logger logger = Logger.getLogger(this.getClass());
     private ApplicationListWidget applicationListWidget;
     private final EventHandlerMyApps eventHandlerMyApps;
+    private TextField searchBar;
 
     public ViewLibrary(MainWindow parent) {
         this.parent = parent;
@@ -59,9 +60,9 @@ public class ViewLibrary extends HBox {
 
         this.getChildren().add(leftContent);
 
-        TextField searchBar = new TextField();
+        searchBar = new TextField();
         searchBar.setOnKeyReleased(event -> {
-            applicationListWidget.search(searchBar);
+            applicationListWidget.search(searchBar.getText());
         });
 
         this.runScript = new LeftButton("/com/playonlinux/ui/impl/javafx/mainwindow/library/script.png", "Run a script");
@@ -101,5 +102,9 @@ public class ViewLibrary extends HBox {
 
     public EventHandlerMyApps getEventHandler() {
         return eventHandlerMyApps;
+    }
+
+    public TextField getSearchBar() {
+        return searchBar;
     }
 }

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
@@ -63,6 +63,9 @@ public class ViewLibrary extends HBox {
         this.getChildren().add(leftContent);
 
         TextField searchBar = new TextField();
+        searchBar.setOnKeyReleased(event -> {
+            applicationListWidget.search(event.getText());
+        });
 
         this.runScript = new LeftButton("/com/playonlinux/ui/impl/javafx/mainwindow/library/script.png", "Run a script");
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
@@ -62,9 +62,7 @@ public class ViewLibrary extends HBox {
         this.getChildren().add(leftContent);
 
         searchBar = new TextField();
-        searchBar.setOnKeyReleased(event -> {
-            applicationListWidget.search(searchBar.getText());
-        });
+        searchBar.setOnKeyReleased(event -> applicationListWidget.search(searchBar.getText()));
 
         this.runScript = new LeftButton("/com/playonlinux/ui/impl/javafx/mainwindow/library/script.png", "Run a script");
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/library/ViewLibrary.java
@@ -44,9 +44,10 @@ public class ViewLibrary extends HBox {
         this.parent = parent;
         this.getStyleClass().add("mainWindowScene");
 
+        eventHandlerMyApps = new EventHandlerMyApps();
+
         this.drawSideBar();
         this.drawContent();
-        eventHandlerMyApps = new EventHandlerMyApps();
     }
 
     private void drawContent() {

--- a/src/test/java/com/playonlinux/common/dto/InstalledApplicationDTOTest.java
+++ b/src/test/java/com/playonlinux/common/dto/InstalledApplicationDTOTest.java
@@ -18,7 +18,7 @@
 
 package com.playonlinux.common.dto;
 
-import com.playonlinux.common.dto.ui.ShortcutDTO;
+import com.playonlinux.common.dto.ui.InstalledApplicationDTO;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,26 +26,26 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-public class ShortcutDTOTest {
+public class InstalledApplicationDTOTest {
 
-    private ShortcutDTO shortcutDto;
+    private InstalledApplicationDTO installedApplicationDto;
 
     @Before
     public void setUp() throws MalformedURLException {
-        this.shortcutDto = new ShortcutDTO.Builder()
+        this.installedApplicationDto = new InstalledApplicationDTO.Builder()
                 .withName("Name")
                 .withIcon(new URL("file://"+new File("/tmp/icon").getAbsolutePath()))
                 .build();
     }
     @Test
     public void testShortcutDTO_CreateDTO_nameIsPopulated() throws Exception {
-        assertEquals("Name", shortcutDto.getName());
+        assertEquals("Name", installedApplicationDto.getName());
     }
 
     @Test
     public void testShortcutDTO_CreateDTO_iconIsPopulated() throws Exception {
-        assertEquals("file:/tmp/icon", shortcutDto.getIcon().toString());
+        assertEquals("file:/tmp/icon", installedApplicationDto.getIcon().toString());
     }
 }


### PR DESCRIPTION
MainWindow search bar now has filtering applied to it:
   * Rename ShortcutDTO to InstalledApplicationDTO for better clarification.
   * Create a new filter for InstalledApplicationDTO.
   * Make ApplicationListWidget apply the new filter for user keypress events on the shown data.

Notes:
   * Left the filter apply() so that it would show all applications on start unlike it is done in ViewApps.
   * ApplicationListWidget update() is called twice on startup. I was not able to tacle the problem but it is currently in the main branch too. Could use some looking into.