### PR TITLE
Outsourcing History and saving cursorPosition.

### DIFF
--- a/src/main/java/com/playonlinux/ui/common/CommandHistory.java
+++ b/src/main/java/com/playonlinux/ui/common/CommandHistory.java
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-package com.playonlinux.ui.impl.javafx.mainwindow.console;
+package com.playonlinux.ui.common;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,48 +26,53 @@ import java.util.List;
  */
 public class CommandHistory {
 
-    private List<Item> history = new ArrayList<>();
+    private final List<Item> history = new ArrayList<>();
     private int historyPosition = 0;
 
-    public void add(Item item){
+    public void add(Item item) {
         this.history.add(item);
         historyPosition = this.history.size();
     }
 
-    public Item up(){
-        if(historyPosition > 0){
+    public Item up() {
+        if (historyPosition > 0) {
             historyPosition--;
         }
         return current();
     }
 
-    public Item down(){
+    public Item down() {
         historyPosition = (historyPosition < history.size()) ? (historyPosition + 1) : history.size();
         return current();
     }
 
-    public Item current(){
-        if(history.size() > 0 && historyPosition < history.size()){
+    public Item current() {
+        if (history.size() > 0 && historyPosition < history.size()) {
             return history.get(historyPosition);
         }
         return Item.empty;
     }
 
 
-    public static class Item {
+    public static final class Item {
 
-        public static Item empty = new Item("", 0);
+        public static final Item empty = new Item("", 0);
 
-        private String command;
-        private int cursorPosition;
+        private final String command;
+        private final int cursorPosition;
 
-        public Item(String command, int cursorPosition){
+        public Item(String command, int cursorPosition) {
             this.command = command;
             this.cursorPosition = cursorPosition;
         }
 
-        public String getCommand(){ return command; }
-        public int getCursorPosition(){ return cursorPosition; }
+        public String getCommand() {
+            return command;
+        }
+
+        public int getCursorPosition() {
+            return cursorPosition;
+        }
 
     }
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/console/CommandHistory.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/console/CommandHistory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.ui.impl.javafx.mainwindow.console;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Small helper intended for keeping track of commands that have been entered into the console window.
+ */
+public class CommandHistory {
+
+    private List<Item> history = new ArrayList<>();
+    private int historyPosition = 0;
+
+    public void add(Item item){
+        this.history.add(item);
+        historyPosition = this.history.size();
+    }
+
+    public Item up(){
+        if(historyPosition > 0){
+            historyPosition--;
+        }
+        return current();
+    }
+
+    public Item down(){
+        historyPosition = (historyPosition < history.size()) ? (historyPosition + 1) : history.size();
+        return current();
+    }
+
+    public Item current(){
+        if(history.size() > 0 && historyPosition < history.size()){
+            return history.get(historyPosition);
+        }
+        return Item.empty;
+    }
+
+
+    public static class Item {
+
+        public static Item empty = new Item("", 0);
+
+        private String command;
+        private int cursorPosition;
+
+        public Item(String command, int cursorPosition){
+            this.command = command;
+            this.cursorPosition = cursorPosition;
+        }
+
+        public String getCommand(){ return command; }
+        public int getCursorPosition(){ return cursorPosition; }
+
+    }
+
+}

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/console/ConsoleTab.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/console/ConsoleTab.java
@@ -99,18 +99,18 @@ public class ConsoleTab extends Tab implements PlayOnLinuxWindow {
                 } else {
                     nextSymbol = INSIDE_BLOCK;
                 }
-            } else if (event.getCode() == KeyCode.UP) {
+            }
+        });
+
+        command.setOnKeyReleased(event -> {
+            if (event.getCode() == KeyCode.UP) {
                 CommandHistory.Item historyItem = commandHistory.up();
-                Platform.runLater(() -> {
-                    command.setText(historyItem.getCommand());
-                    command.positionCaret(historyItem.getCursorPosition());
-                });
+                command.setText(historyItem.getCommand());
+                command.positionCaret(historyItem.getCursorPosition());
             } else if (event.getCode() == KeyCode.DOWN) {
                 CommandHistory.Item historyItem = commandHistory.down();
-                Platform.runLater(() -> {
-                    command.setText(historyItem.getCommand());
-                    command.positionCaret(historyItem.getCursorPosition());
-                });
+                command.setText(historyItem.getCommand());
+                command.positionCaret(historyItem.getCursorPosition());
             }
         });
 

--- a/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/console/ConsoleTab.java
+++ b/src/main/java/com/playonlinux/ui/impl/javafx/mainwindow/console/ConsoleTab.java
@@ -26,6 +26,7 @@ import com.playonlinux.core.python.CommandInterpreter;
 import com.playonlinux.core.python.CommandInterpreterException;
 import com.playonlinux.ui.api.CommandLineInterpreterFactory;
 import com.playonlinux.ui.api.PlayOnLinuxWindow;
+import com.playonlinux.ui.common.CommandHistory;
 import javafx.application.Platform;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tab;
@@ -36,9 +37,6 @@ import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static com.playonlinux.core.lang.Localisation.translate;
 
 @Scan
@@ -47,7 +45,7 @@ public class ConsoleTab extends Tab implements PlayOnLinuxWindow {
     private static final String NOT_INSIDE_BLOCK = ">>> ";
     private static final String INSIDE_BLOCK = "... ";
 
-    private CommandHistory commandHistory = new CommandHistory();
+    private final CommandHistory commandHistory = new CommandHistory();
 
     @Inject
     static CommandLineInterpreterFactory commandLineInterpreterFactory;

--- a/src/test/java/com/playonlinux/ui/common/CommandHistoryTest.java
+++ b/src/test/java/com/playonlinux/ui/common/CommandHistoryTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2015 Markus Ebner
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.playonlinux.ui.common;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CommandHistoryTest {
+
+    private final CommandHistory history = new CommandHistory();
+
+    private CommandHistory.Item[] testItems = new CommandHistory.Item[2];
+
+    @Before
+    public void setUp() {
+        testItems[0] = new CommandHistory.Item("item0", 3);
+        testItems[1] = new CommandHistory.Item("item1", 4);
+    }
+
+    @Test
+    public void testHistory() {
+        //empty history should always return an empty item.
+        assertEquals(CommandHistory.Item.empty, history.current());
+        history.up();
+        history.up();
+        assertEquals(CommandHistory.Item.empty, history.current());
+        history.down();
+        assertEquals(CommandHistory.Item.empty, history.current());
+
+        history.add(testItems[0]);
+        //history should be reset to point to an empty item after adding a new item
+        assertEquals(CommandHistory.Item.empty, history.current());
+        //after going one up, history should be at the latest added item.
+        assertEquals(testItems[0], history.up());
+        assertEquals(testItems[0], history.current());
+        //calling up even though the history is already pointing to the oldest item should
+        //have no effect => still pointing to the oldest item
+        assertEquals(testItems[0], history.up());
+        assertEquals(testItems[0], history.current());
+        //going back down should result in the history pointing to an empty item
+        assertEquals(CommandHistory.Item.empty, history.down());
+        assertEquals(CommandHistory.Item.empty, history.current());
+
+        history.add(testItems[1]);
+        //history should always point to an empty item after adding a new item
+        assertEquals(CommandHistory.Item.empty, history.current());
+        //after going one up, history should be at the latest added item.
+        assertEquals(testItems[1], history.up());
+        assertEquals(testItems[1], history.current());
+        //after going up once more, history should point at the second latest added item.
+        assertEquals(testItems[0], history.up());
+        assertEquals(testItems[0], history.current());
+        //going back down, history should again point to the latest added item
+        assertEquals(testItems[1], history.down());
+        assertEquals(testItems[1], history.current());
+    }
+
+}


### PR DESCRIPTION
The History is now handled in the small helper class `CommandHistory`.
Now not only the command itself, but also the cursorPosition when hitting enter is saved and restored.

The `CommandHistory` helper should probably be moved out of impl.javafx, since it can at least be shared with the gtk gui.