### PR TITLE
Fix for external dependencies installation in mvn clean goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
                 <version>2.4</version>
                 <executions>
                     <execution>
-                        <id>install-external</id>
+                        <id>install-external-gtk</id>
                         <phase>clean</phase>
                         <configuration>
                             <file>${basedir}/dependencies/gtk-4.1.jar</file>
@@ -243,15 +243,8 @@
                             <goal>install-file</goal>
                         </goals>
                     </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
                     <execution>
-                        <id>install-external</id>
+                        <id>install-external-qt</id>
                         <phase>clean</phase>
                         <configuration>
                             <file>${basedir}/dependencies/qtjambi-4.8.7.jar</file>


### PR DESCRIPTION
Make sure both dependencies get installed when executing mvn clean. Before, only the qtjambi dependency would be installed.