### PR TITLE
[Qt] Add File-Extension filter to runLocalScript-dialog

### DIFF
--- a/phoenicis-qt/src/main/java/com/playonlinux/qt/mainwindow/MainWindowEventHandler.java
+++ b/phoenicis-qt/src/main/java/com/playonlinux/qt/mainwindow/MainWindowEventHandler.java
@@ -113,8 +113,9 @@ public class MainWindowEventHandler implements UIEventHandler {
         QFileDialog fileDialog = new QFileDialog(mainWindow);
         fileDialog.setDirectory(lastLocalScriptDir);
         fileDialog.setFileMode(QFileDialog.FileMode.ExistingFile);
-        fileDialog.setViewMode(QFileDialog.ViewMode.List);
         fileDialog.setAcceptMode(QFileDialog.AcceptMode.AcceptOpen);
+        fileDialog.setNameFilter("POL Scriptfiles (*.py *.sh)");
+        fileDialog.setNameFilterDetailsVisible(true);
         if (fileDialog.exec() == QDialog.DialogCode.Accepted.value()) {
             File scriptFile = new File(fileDialog.selectedFiles().get(0));
 


### PR DESCRIPTION
Add a fileExtension-filter to the dialog for running local scripts.