### PR TITLE
[JavaFX] Fix BrowseStep next-button always enabled

### DIFF
--- a/phoenicis-javafx/src/main/java/com/playonlinux/javafx/setupwindow/StepRepresentationBrowse.java
+++ b/phoenicis-javafx/src/main/java/com/playonlinux/javafx/setupwindow/StepRepresentationBrowse.java
@@ -54,11 +54,15 @@ public class StepRepresentationBrowse extends StepRepresentationMessage {
             }
             fileChooser.setInitialDirectory(browseDirectory);
 
-            selectedFile = fileChooser.showOpenDialog(this.getParentWindow());
+            File dialogResult = fileChooser.showOpenDialog(this.getParentWindow());
+            if(dialogResult != null){
+                selectedFile = dialogResult;
+                setNextButtonEnabled(true);
+            }
         });
 
-
         this.addToStep(browseButton);
+        this.setNextButtonEnabled(false);
     }
 
     @Override


### PR DESCRIPTION
The next-button is now enabled when the user first selects a valid file from the dialog.
Canceling the dialog does not reset the before chosen file.