### PR TITLE
HTTPDownloader as Consumer

### DIFF
--- a/phoenicis-core/src/main/java/com/playonlinux/apps/AppsEntitiesProvider.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/apps/AppsEntitiesProvider.java
@@ -31,7 +31,7 @@ import com.playonlinux.apps.entities.AppEntity;
 import com.playonlinux.apps.entities.AppsCategoryEntity;
 import com.playonlinux.apps.entities.AppsWindowEntity;
 import com.playonlinux.apps.entities.ScriptEntity;
-import com.playonlinux.core.entities.ProgressEntity;
+import com.playonlinux.core.entities.ProgressState;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
 import com.playonlinux.core.observer.Observer;
 import com.playonlinux.core.services.manager.ServiceInitializationException;
@@ -76,11 +76,11 @@ public final class AppsEntitiesProvider
 
 
     private boolean isUpdating() {
-        return downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.PROGRESSING;
+        return downloadEnvelope.getDownloadState().getState() == ProgressState.PROGRESSING;
     }
 
     private boolean hasFailed() {
-        return downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.FAILED;
+        return downloadEnvelope.getDownloadState().getState() == ProgressState.FAILED;
     }
 
 

--- a/phoenicis-core/src/main/java/com/playonlinux/apps/AppsEntitiesProvider.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/apps/AppsEntitiesProvider.java
@@ -31,7 +31,7 @@ import com.playonlinux.apps.entities.AppEntity;
 import com.playonlinux.apps.entities.AppsCategoryEntity;
 import com.playonlinux.apps.entities.AppsWindowEntity;
 import com.playonlinux.apps.entities.ScriptEntity;
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
 import com.playonlinux.core.observer.Observer;
 import com.playonlinux.core.services.manager.ServiceInitializationException;
@@ -76,11 +76,11 @@ public final class AppsEntitiesProvider
 
 
     private boolean isUpdating() {
-        return downloadEnvelope.getDownloadState().getState() == ProgressStateEntity.State.PROGRESSING;
+        return downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.PROGRESSING;
     }
 
     private boolean hasFailed() {
-        return downloadEnvelope.getDownloadState().getState() == ProgressStateEntity.State.FAILED;
+        return downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.FAILED;
     }
 
 

--- a/phoenicis-core/src/main/java/com/playonlinux/apps/DefaultAppsManager.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/apps/DefaultAppsManager.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 
 import com.playonlinux.app.PlayOnLinuxContext;
 import com.playonlinux.apps.dto.CategoryDTO;
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 import com.playonlinux.core.gpg.SignatureChecker;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
 import com.playonlinux.core.scripts.InstallerSource;
@@ -49,11 +49,11 @@ public class DefaultAppsManager extends ObservableDefaultImplementation<DefaultA
     private DownloadEnvelope<Collection<CategoryDTO>> downloadEnvelope;
 
     public boolean isUpdating() {
-        return downloadEnvelope == null || downloadEnvelope.getDownloadState().getState() == ProgressStateEntity.State.PROGRESSING;
+        return downloadEnvelope == null || downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.PROGRESSING;
     }
 
     public boolean hasFailed() {
-        return downloadEnvelope.getDownloadState().getState() == ProgressStateEntity.State.FAILED;
+        return downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.FAILED;
     }
 
     @Override

--- a/phoenicis-core/src/main/java/com/playonlinux/apps/DefaultAppsManager.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/apps/DefaultAppsManager.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 
 import com.playonlinux.app.PlayOnLinuxContext;
 import com.playonlinux.apps.dto.CategoryDTO;
-import com.playonlinux.core.entities.ProgressEntity;
+import com.playonlinux.core.entities.ProgressState;
 import com.playonlinux.core.gpg.SignatureChecker;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
 import com.playonlinux.core.scripts.InstallerSource;
@@ -49,11 +49,11 @@ public class DefaultAppsManager extends ObservableDefaultImplementation<DefaultA
     private DownloadEnvelope<Collection<CategoryDTO>> downloadEnvelope;
 
     public boolean isUpdating() {
-        return downloadEnvelope == null || downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.PROGRESSING;
+        return downloadEnvelope == null || downloadEnvelope.getDownloadState().getState() == ProgressState.PROGRESSING;
     }
 
     public boolean hasFailed() {
-        return downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.FAILED;
+        return downloadEnvelope.getDownloadState().getState() == ProgressState.FAILED;
     }
 
     @Override

--- a/phoenicis-core/src/main/java/com/playonlinux/apps/DefaultInstallerDownloaderEntityProvider.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/apps/DefaultInstallerDownloaderEntityProvider.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import org.apache.log4j.Logger;
 
 import com.playonlinux.apps.entities.InstallerDownloaderEntity;
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 import com.playonlinux.core.gpg.SignatureChecker;
 import com.playonlinux.core.gpg.SignatureException;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
@@ -123,8 +123,8 @@ public class DefaultInstallerDownloaderEntityProvider
         SIGNATURE_ERROR
     }
 
-    public void update(ProgressStateEntity argument) {
-        if(argument.getState() == ProgressStateEntity.State.PROGRESSING) {
+    public void update(ProgressEntity argument) {
+        if(argument.getState() == ProgressEntity.State.PROGRESSING) {
             changeState(State.PROGRESSING, argument.getPercent());
         }
     }

--- a/phoenicis-core/src/main/java/com/playonlinux/apps/DefaultInstallerDownloaderEntityProvider.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/apps/DefaultInstallerDownloaderEntityProvider.java
@@ -26,6 +26,7 @@ import org.apache.log4j.Logger;
 
 import com.playonlinux.apps.entities.InstallerDownloaderEntity;
 import com.playonlinux.core.entities.ProgressEntity;
+import com.playonlinux.core.entities.ProgressState;
 import com.playonlinux.core.gpg.SignatureChecker;
 import com.playonlinux.core.gpg.SignatureException;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
@@ -124,7 +125,7 @@ public class DefaultInstallerDownloaderEntityProvider
     }
 
     public void update(ProgressEntity argument) {
-        if(argument.getState() == ProgressEntity.State.PROGRESSING) {
+        if(argument.getState() == ProgressState.PROGRESSING) {
             changeState(State.PROGRESSING, argument.getPercent());
         }
     }

--- a/phoenicis-core/src/main/java/com/playonlinux/apps/DefaultInstallerDownloaderEntityProvider.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/apps/DefaultInstallerDownloaderEntityProvider.java
@@ -29,7 +29,6 @@ import com.playonlinux.core.entities.ProgressStateEntity;
 import com.playonlinux.core.gpg.SignatureChecker;
 import com.playonlinux.core.gpg.SignatureException;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
-import com.playonlinux.core.observer.Observer;
 import com.playonlinux.core.scripts.AnyScriptFactory;
 import com.playonlinux.core.scripts.Script;
 import com.playonlinux.core.scripts.ScriptFailureException;
@@ -43,8 +42,7 @@ import com.playonlinux.injection.Scan;
 @Scan
 public class DefaultInstallerDownloaderEntityProvider
         extends ObservableDefaultImplementation<InstallerDownloaderEntity>
-        implements InstallerDownloaderEntityProvider,
-                   Observer<HTTPDownloader, ProgressStateEntity> {
+        implements InstallerDownloaderEntityProvider {
     public static final double PERCENTAGE = 100.;
 
     @Inject
@@ -74,7 +72,7 @@ public class DefaultInstallerDownloaderEntityProvider
 
     @Override
     public void getScript() {
-        httpDownloader.addObserver(this);
+        httpDownloader.setOnChange(this::update);
 
         downloadManager.submit(httpDownloader, bytes -> {
             success(bytes);
@@ -125,8 +123,7 @@ public class DefaultInstallerDownloaderEntityProvider
         SIGNATURE_ERROR
     }
 
-    @Override
-    public void update(HTTPDownloader observable, ProgressStateEntity argument) {
+    public void update(ProgressStateEntity argument) {
         if(argument.getState() == ProgressStateEntity.State.PROGRESSING) {
             changeState(State.PROGRESSING, argument.getPercent());
         }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/entities/ProgressEntity.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/entities/ProgressEntity.java
@@ -25,7 +25,7 @@ import com.playonlinux.core.dto.DTO;
  * The UI will be able to represent this progress state (progressbar, etc...)
  */
 public class ProgressEntity implements DTO {
-    private final State state;
+    private final ProgressState state;
     private final double percent;
 
     private final String progressText;
@@ -36,7 +36,7 @@ public class ProgressEntity implements DTO {
         this.progressText = builder.progressText;
     }
 
-    public State getState() {
+    public ProgressState getState() {
         return state;
     }
 
@@ -48,20 +48,13 @@ public class ProgressEntity implements DTO {
         return progressText;
     }
 
-    public enum State {
-        READY,
-        PROGRESSING,
-        SUCCESS,
-        FAILED
-    }
-
     @Override
     public String toString() {
         return this.state.name();
     }
 
     public static class Builder {
-        private State state;
+        private ProgressState state;
         private double percent;
         private String progressText;
 
@@ -75,7 +68,7 @@ public class ProgressEntity implements DTO {
 
         }
 
-        public Builder withState(State state) {
+        public Builder withState(ProgressState state) {
             this.state = state;
             return this;
         }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/entities/ProgressEntity.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/entities/ProgressEntity.java
@@ -24,13 +24,13 @@ import com.playonlinux.core.dto.DTO;
  * Represent a progress state that will be sent to the UI.
  * The UI will be able to represent this progress state (progressbar, etc...)
  */
-public class ProgressStateEntity implements DTO {
+public class ProgressEntity implements DTO {
     private final State state;
     private final double percent;
 
     private final String progressText;
 
-    public ProgressStateEntity(Builder builder) {
+    public ProgressEntity(Builder builder) {
         this.state = builder.state;
         this.percent = builder.percent;
         this.progressText = builder.progressText;
@@ -65,7 +65,7 @@ public class ProgressStateEntity implements DTO {
         private double percent;
         private String progressText;
 
-        public Builder(ProgressStateEntity other) {
+        public Builder(ProgressEntity other) {
             state = other.state;
             percent = other.percent;
             progressText = other.progressText;
@@ -90,8 +90,8 @@ public class ProgressStateEntity implements DTO {
             return this;
         }
 
-        public ProgressStateEntity build() {
-            return new ProgressStateEntity(this);
+        public ProgressEntity build() {
+            return new ProgressEntity(this);
         }
     }
 }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/entities/ProgressState.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/entities/ProgressState.java
@@ -1,0 +1,5 @@
+package com.playonlinux.core.entities;
+
+public enum ProgressState {
+    READY, PROGRESSING, SUCCESS, FAILED
+}

--- a/phoenicis-core/src/main/java/com/playonlinux/core/utils/ChecksumCalculator.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/utils/ChecksumCalculator.java
@@ -31,13 +31,13 @@ import java.util.function.Consumer;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
 
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 
 public class ChecksumCalculator {
     private static final int BLOCK_SIZE = 2048;
     private static final String WAIT_MESSAGE = translate("Please wait while we are verifying the file...");
 
-    private Consumer<ProgressStateEntity> onChange;
+    private Consumer<ProgressEntity> onChange;
     
     public String calculate(File fileToCheck, String algorithm) throws IOException {
         final long fileSize = FileUtils.sizeOf(fileToCheck);
@@ -73,14 +73,14 @@ public class ChecksumCalculator {
     }
 
     private void changeState(double percentage) {
-        onChange.accept(new ProgressStateEntity.Builder()
+        onChange.accept(new ProgressEntity.Builder()
                 .withPercent(percentage)
                 .withProgressText(WAIT_MESSAGE)
                 .build()
         );
     }
 
-    public void setOnChange(Consumer<ProgressStateEntity> onChange) {
+    public void setOnChange(Consumer<ProgressEntity> onChange) {
         this.onChange = onChange;
     }
 }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/utils/ChecksumCalculator.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/utils/ChecksumCalculator.java
@@ -73,11 +73,13 @@ public class ChecksumCalculator {
     }
 
     private void changeState(double percentage) {
-        onChange.accept(new ProgressEntity.Builder()
-                .withPercent(percentage)
-                .withProgressText(WAIT_MESSAGE)
-                .build()
-        );
+        if(onChange != null){
+            onChange.accept(new ProgressEntity.Builder()
+                    .withPercent(percentage)
+                    .withProgressText(WAIT_MESSAGE)
+                    .build()
+            );
+        }
     }
 
     public void setOnChange(Consumer<ProgressEntity> onChange) {

--- a/phoenicis-core/src/main/java/com/playonlinux/core/utils/archive/Extractor.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/utils/archive/Extractor.java
@@ -62,8 +62,9 @@ public class Extractor {
 
 
     private Void changeState(ProgressEntity progressStateEntity) {
-        //TODO Check if using an other functional interface is possible
-        onChange.accept(progressStateEntity);
+        if(onChange != null){
+            onChange.accept(progressStateEntity);
+        }
         return null;
     }
 

--- a/phoenicis-core/src/main/java/com/playonlinux/core/utils/archive/Extractor.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/utils/archive/Extractor.java
@@ -20,17 +20,19 @@ package com.playonlinux.core.utils.archive;
 
 import java.io.File;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.log4j.Logger;
 
 import com.playonlinux.app.PlayOnLinuxException;
 import com.playonlinux.core.entities.ProgressStateEntity;
-import com.playonlinux.core.observer.ObservableDefaultImplementation;
 import com.playonlinux.core.utils.FileAnalyser;
 
-public class Extractor  extends ObservableDefaultImplementation<ProgressStateEntity> {
+public class Extractor {
     private static final Logger LOGGER = Logger.getLogger(Tar.class);
 
+    private Consumer<ProgressStateEntity> onChange;
+    
     /**
      * Uncompress a .tar file
      * @param inputFile input file
@@ -60,7 +62,13 @@ public class Extractor  extends ObservableDefaultImplementation<ProgressStateEnt
 
 
     private Void changeState(ProgressStateEntity progressStateEntity) {
-        this.notifyObservers(progressStateEntity);
+        //TODO Check if using an other functional interface is possible
+        onChange.accept(progressStateEntity);
         return null;
+    }
+
+
+    public void setOnChange(Consumer<ProgressStateEntity> onChange) {
+        this.onChange = onChange;
     }
 }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/utils/archive/Extractor.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/utils/archive/Extractor.java
@@ -25,13 +25,13 @@ import java.util.function.Consumer;
 import org.apache.log4j.Logger;
 
 import com.playonlinux.app.PlayOnLinuxException;
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 import com.playonlinux.core.utils.FileAnalyser;
 
 public class Extractor {
     private static final Logger LOGGER = Logger.getLogger(Tar.class);
 
-    private Consumer<ProgressStateEntity> onChange;
+    private Consumer<ProgressEntity> onChange;
     
     /**
      * Uncompress a .tar file
@@ -61,14 +61,14 @@ public class Extractor {
     }
 
 
-    private Void changeState(ProgressStateEntity progressStateEntity) {
+    private Void changeState(ProgressEntity progressStateEntity) {
         //TODO Check if using an other functional interface is possible
         onChange.accept(progressStateEntity);
         return null;
     }
 
 
-    public void setOnChange(Consumer<ProgressStateEntity> onChange) {
+    public void setOnChange(Consumer<ProgressEntity> onChange) {
         this.onChange = onChange;
     }
 }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/utils/archive/Tar.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/utils/archive/Tar.java
@@ -41,7 +41,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 
 import com.google.common.io.CountingInputStream;
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 
 
 /**
@@ -51,7 +51,7 @@ public class Tar  {
     private static final Logger LOGGER = Logger.getLogger(Tar.class);
     private static final String TAR_ERROR_MESSAGE = "Unable to open input stream";
 
-    List<File> uncompressTarBz2File(File inputFile, File outputDir, Function<ProgressStateEntity, Void> stateCallback) throws ArchiveException {
+    List<File> uncompressTarBz2File(File inputFile, File outputDir, Function<ProgressEntity, Void> stateCallback) throws ArchiveException {
         try(CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile)) ;
             InputStream inputStream = new BZip2CompressorInputStream(countingInputStream)) {
             final long finalSize = FileUtils.sizeOf(inputFile);
@@ -61,7 +61,7 @@ public class Tar  {
         }
     }
 
-    List<File> uncompressTarGzFile(File inputFile, File outputDir, Function<ProgressStateEntity, Void> stateCallback) throws ArchiveException {
+    List<File> uncompressTarGzFile(File inputFile, File outputDir, Function<ProgressEntity, Void> stateCallback) throws ArchiveException {
         try(CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile)) ;
             InputStream inputStream = new GZIPInputStream(countingInputStream)) {
             final long finalSize = FileUtils.sizeOf(inputFile);
@@ -71,7 +71,7 @@ public class Tar  {
         }
     }
 
-    List<File> uncompressTarXzFile(File inputFile, File outputDir, Function<ProgressStateEntity, Void> stateCallback) throws ArchiveException {
+    List<File> uncompressTarXzFile(File inputFile, File outputDir, Function<ProgressEntity, Void> stateCallback) throws ArchiveException {
         try(CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile)) ;
             InputStream inputStream = new XZCompressorInputStream(countingInputStream)) {
             final long finalSize = FileUtils.sizeOf(inputFile);
@@ -81,7 +81,7 @@ public class Tar  {
         }
     }
 
-    List<File> uncompressTarFile(File inputFile, File outputDir, Function<ProgressStateEntity, Void> stateCallback) throws ArchiveException {
+    List<File> uncompressTarFile(File inputFile, File outputDir, Function<ProgressEntity, Void> stateCallback) throws ArchiveException {
         try(CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(inputFile))) {
             final long finalSize = FileUtils.sizeOf(inputFile);
             return uncompress(countingInputStream, countingInputStream, outputDir, finalSize, stateCallback);
@@ -99,7 +99,7 @@ public class Tar  {
      * @throws ArchiveException if the process fails
      */
     private List<File> uncompress(final InputStream inputStream, CountingInputStream countingInputStream, final File outputDir, long finalSize,
-                                  Function<ProgressStateEntity, Void> stateCallback) throws ArchiveException {
+                                  Function<ProgressEntity, Void> stateCallback) throws ArchiveException {
         final List<File> uncompressedFiles = new LinkedList<>();
         try(ArchiveInputStream debInputStream = new ArchiveStreamFactory().createArchiveInputStream("tar", inputStream)) {
             TarArchiveEntry entry;
@@ -132,7 +132,7 @@ public class Tar  {
                 }
                 uncompressedFiles.add(outputFile);
 
-                stateCallback.apply(new ProgressStateEntity.Builder()
+                stateCallback.apply(new ProgressEntity.Builder()
                                 .withPercent((double) countingInputStream.getCount() / (double) finalSize * (double) 100)
                                 .withProgressText("Extracting " + outputFile.getName())
                                 .build()

--- a/phoenicis-core/src/main/java/com/playonlinux/core/webservice/DownloadEnvelope.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/webservice/DownloadEnvelope.java
@@ -18,12 +18,12 @@
 
 package com.playonlinux.core.webservice;
 
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 
 public class DownloadEnvelope<C> {
 
     C envelopeContent;
-    ProgressStateEntity downloadState;
+    ProgressEntity downloadState;
 
     public C getEnvelopeContent() {
         return envelopeContent;
@@ -33,11 +33,11 @@ public class DownloadEnvelope<C> {
         this.envelopeContent = envelopeContent;
     }
 
-    public ProgressStateEntity getDownloadState() {
+    public ProgressEntity getDownloadState() {
         return downloadState;
     }
 
-    public void setDownloadState(ProgressStateEntity downloadState) {
+    public void setDownloadState(ProgressEntity downloadState) {
         this.downloadState = downloadState;
     }
 }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
@@ -36,7 +36,6 @@ public class HTTPDownloader extends ObservableDefaultImplementation<ProgressStat
 
     private static final int BLOCK_SIZE = 1024;
     private final URL url;
-    private State state;
     private float percentage;
 
     public enum State {
@@ -45,8 +44,7 @@ public class HTTPDownloader extends ObservableDefaultImplementation<ProgressStat
 
     public HTTPDownloader(URL url) {
         this.url = url;
-        this.state = State.READY;
-        this.changeState();
+        changeState(State.READY);
     }
 
     private HttpURLConnection openConnection(URL remoteFile) throws IOException {
@@ -67,26 +65,22 @@ public class HTTPDownloader extends ObservableDefaultImplementation<ProgressStat
                 bufferedOutputStream.write(data, 0, i);
 
                 this.percentage = totalDataRead * 100 / fileSize;
-                this.state = State.PROGRESSING;
-                this.changeState();
+                changeState(State.PROGRESSING);
 
                 if (Thread.currentThread().isInterrupted()) {
                     throw new InterruptedException("The download has been aborted");
                 }
             }
         } catch (IOException | InterruptedException e) {
-            this.state = State.FAILED;
-            this.changeState();
+            changeState(State.FAILED);
             throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, this.url), e);
         }
-        this.state = State.SUCCESS;
-        this.changeState();
-
+        changeState(State.SUCCESS);
     }
 
-    private void changeState() {
+    private void changeState(State state) {
         ProgressStateEntity currentState = new ProgressStateEntity.Builder().withPercent(this.percentage)
-                .withState(ProgressStateEntity.State.valueOf(this.state.name())).build();
+                .withState(ProgressStateEntity.State.valueOf(state.name())).build();
         this.notifyObservers(currentState);
     }
 

--- a/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
@@ -40,93 +40,88 @@ public class HTTPDownloader extends ObservableDefaultImplementation<ProgressStat
     private float percentage;
 
     public enum State {
-	READY, PROGRESSING, SUCCESS, FAILED
+        READY, PROGRESSING, SUCCESS, FAILED
     }
 
     public HTTPDownloader(URL url) {
-	this.url = url;
-	this.state = State.READY;
-	this.changeState();
+        this.url = url;
+        this.state = State.READY;
+        this.changeState();
     }
 
     private HttpURLConnection openConnection(URL remoteFile) throws IOException {
-	return (HttpURLConnection) remoteFile.openConnection();
+        return (HttpURLConnection) remoteFile.openConnection();
     }
 
     private void saveConnectionToStream(HttpURLConnection connection, OutputStream outputStream)
-	    throws DownloadException {
-	int fileSize = connection.getContentLength();
+            throws DownloadException {
+        int fileSize = connection.getContentLength();
 
-	try {
-	    BufferedInputStream inputStream = new BufferedInputStream(connection.getInputStream());
-	    BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outputStream, BLOCK_SIZE);
+        try (BufferedInputStream inputStream = new BufferedInputStream(connection.getInputStream());
+                BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outputStream, BLOCK_SIZE)) {
+            byte[] data = new byte[BLOCK_SIZE];
+            int i;
+            float totalDataRead = 0.0F;
+            while ((i = inputStream.read(data, 0, BLOCK_SIZE)) >= 0) {
+                totalDataRead += i;
+                bufferedOutputStream.write(data, 0, i);
 
-	    byte[] data = new byte[BLOCK_SIZE];
-	    int i;
-	    float totalDataRead = 0.0F;
-	    while ((i = inputStream.read(data, 0, BLOCK_SIZE)) >= 0) {
-		totalDataRead += i;
-		bufferedOutputStream.write(data, 0, i);
+                this.percentage = totalDataRead * 100 / fileSize;
+                this.state = State.PROGRESSING;
+                this.changeState();
 
-		this.percentage = totalDataRead * 100 / fileSize;
-		this.state = State.PROGRESSING;
-		this.changeState();
-
-		if (Thread.currentThread().isInterrupted()) {
-		    throw new InterruptedException("The download has been aborted");
-		}
-	    }
-
-	    inputStream.close();
-	    bufferedOutputStream.close();
-	} catch (IOException | InterruptedException e) {
-	    this.state = State.FAILED;
-	    this.changeState();
-	    throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, this.url), e);
-	}
-	this.state = State.SUCCESS;
-	this.changeState();
+                if (Thread.currentThread().isInterrupted()) {
+                    throw new InterruptedException("The download has been aborted");
+                }
+            }
+        } catch (IOException | InterruptedException e) {
+            this.state = State.FAILED;
+            this.changeState();
+            throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, this.url), e);
+        }
+        this.state = State.SUCCESS;
+        this.changeState();
 
     }
 
     private void changeState() {
-	ProgressStateEntity currentState = new ProgressStateEntity.Builder().withPercent(this.percentage)
-		.withState(ProgressStateEntity.State.valueOf(this.state.name())).build();
-	this.notifyObservers(currentState);
+        ProgressStateEntity currentState = new ProgressStateEntity.Builder().withPercent(this.percentage)
+                .withState(ProgressStateEntity.State.valueOf(this.state.name())).build();
+        this.notifyObservers(currentState);
     }
 
     public void get(File localFile) throws DownloadException {
-	try {
-	    get(new FileOutputStream(localFile));
-	} catch (IOException e) {
-	    throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, this.url), e);
-	}
+        try {
+            get(new FileOutputStream(localFile));
+        } catch (IOException e) {
+            throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, this.url), e);
+        }
     }
 
     public void get(OutputStream outputStream) throws DownloadException {
-	HttpURLConnection connection;
-	try {
-	    connection = openConnection(url);
-	} catch (IOException e) {
-	    throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, this.url), e);
-	}
+        HttpURLConnection connection;
+        try {
+            connection = openConnection(url);
+        } catch (IOException e) {
+            throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, this.url), e);
+        }
 
-	this.saveConnectionToStream(connection, outputStream);
+        this.saveConnectionToStream(connection, outputStream);
 
     }
 
     public String get() throws DownloadException {
-	return new String(getBytes());
+        return new String(getBytes());
     }
 
     public byte[] getBytes() throws DownloadException {
-	ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-	get(outputStream);
-	try {
-	    outputStream.flush();
-	} catch (IOException e) {
-	    throw new DownloadException("Download failed", e);
-	}
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        get(outputStream);
+        try {
+            outputStream.flush();
+        } catch (IOException e) {
+            throw new DownloadException("Download failed", e);
+        }
         return outputStream.toByteArray();
     }
 }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
@@ -127,6 +127,6 @@ public class HTTPDownloader extends ObservableDefaultImplementation<ProgressStat
 	} catch (IOException e) {
 	    throw new DownloadException("Download failed", e);
 	}
-	return outputStream.toByteArray();
+        return outputStream.toByteArray();
     }
 }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.util.function.Consumer;
 
 import com.playonlinux.core.entities.ProgressEntity;
+import com.playonlinux.core.entities.ProgressState;
 
 public class HTTPDownloader {
     private static final String EXCEPTION_ITEM_DOWNLOAD_FAILED = "Download of %s has failed";
@@ -38,14 +39,10 @@ public class HTTPDownloader {
     private final URL url;
     private float percentage;
     private Consumer<ProgressEntity> onChange;
-    
-    public enum State {
-        READY, PROGRESSING, SUCCESS, FAILED
-    }
 
     public HTTPDownloader(URL url) {
         this.url = url;
-        changeState(State.READY);
+        changeState(ProgressState.READY);
     }
 
     private HttpURLConnection openConnection(URL remoteFile) throws IOException {
@@ -66,22 +63,22 @@ public class HTTPDownloader {
                 bufferedOutputStream.write(data, 0, i);
 
                 this.percentage = totalDataRead * 100 / fileSize;
-                changeState(State.PROGRESSING);
+                changeState(ProgressState.PROGRESSING);
 
                 if (Thread.currentThread().isInterrupted()) {
                     throw new InterruptedException("The download has been aborted");
                 }
             }
         } catch (IOException | InterruptedException e) {
-            changeState(State.FAILED);
+            changeState(ProgressState.FAILED);
             throw new DownloadException(String.format(EXCEPTION_ITEM_DOWNLOAD_FAILED, this.url), e);
         }
-        changeState(State.SUCCESS);
+        changeState(ProgressState.SUCCESS);
     }
 
-    private void changeState(State state) {
+    private void changeState(ProgressState state) {
         ProgressEntity currentState = new ProgressEntity.Builder().withPercent(this.percentage)
-                .withState(ProgressEntity.State.valueOf(state.name())).build();
+                .withState(state).build();
         onChange.accept(currentState);
     }
 

--- a/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
@@ -27,17 +27,18 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.function.Consumer;
 
 import com.playonlinux.core.entities.ProgressStateEntity;
-import com.playonlinux.core.observer.ObservableDefaultImplementation;
 
-public class HTTPDownloader extends ObservableDefaultImplementation<ProgressStateEntity> {
+public class HTTPDownloader {
     private static final String EXCEPTION_ITEM_DOWNLOAD_FAILED = "Download of %s has failed";
 
     private static final int BLOCK_SIZE = 1024;
     private final URL url;
     private float percentage;
-
+    private Consumer<ProgressStateEntity> onChange;
+    
     public enum State {
         READY, PROGRESSING, SUCCESS, FAILED
     }
@@ -81,7 +82,7 @@ public class HTTPDownloader extends ObservableDefaultImplementation<ProgressStat
     private void changeState(State state) {
         ProgressStateEntity currentState = new ProgressStateEntity.Builder().withPercent(this.percentage)
                 .withState(ProgressStateEntity.State.valueOf(state.name())).build();
-        this.notifyObservers(currentState);
+        onChange.accept(currentState);
     }
 
     public void get(File localFile) throws DownloadException {
@@ -117,5 +118,9 @@ public class HTTPDownloader extends ObservableDefaultImplementation<ProgressStat
             throw new DownloadException("Download failed", e);
         }
         return outputStream.toByteArray();
+    }
+
+    public void setOnChange(Consumer<ProgressStateEntity> onChange) {
+        this.onChange = onChange;
     }
 }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
@@ -29,7 +29,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.function.Consumer;
 
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 
 public class HTTPDownloader {
     private static final String EXCEPTION_ITEM_DOWNLOAD_FAILED = "Download of %s has failed";
@@ -37,7 +37,7 @@ public class HTTPDownloader {
     private static final int BLOCK_SIZE = 1024;
     private final URL url;
     private float percentage;
-    private Consumer<ProgressStateEntity> onChange;
+    private Consumer<ProgressEntity> onChange;
     
     public enum State {
         READY, PROGRESSING, SUCCESS, FAILED
@@ -80,8 +80,8 @@ public class HTTPDownloader {
     }
 
     private void changeState(State state) {
-        ProgressStateEntity currentState = new ProgressStateEntity.Builder().withPercent(this.percentage)
-                .withState(ProgressStateEntity.State.valueOf(state.name())).build();
+        ProgressEntity currentState = new ProgressEntity.Builder().withPercent(this.percentage)
+                .withState(ProgressEntity.State.valueOf(state.name())).build();
         onChange.accept(currentState);
     }
 
@@ -120,7 +120,7 @@ public class HTTPDownloader {
         return outputStream.toByteArray();
     }
 
-    public void setOnChange(Consumer<ProgressStateEntity> onChange) {
+    public void setOnChange(Consumer<ProgressEntity> onChange) {
         this.onChange = onChange;
     }
 }

--- a/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/webservice/HTTPDownloader.java
@@ -77,9 +77,11 @@ public class HTTPDownloader {
     }
 
     private void changeState(ProgressState state) {
-        ProgressEntity currentState = new ProgressEntity.Builder().withPercent(this.percentage)
-                .withState(state).build();
-        onChange.accept(currentState);
+        if(onChange != null){
+            ProgressEntity currentState = new ProgressEntity.Builder().withPercent(this.percentage)
+                    .withState(state).build();
+            onChange.accept(currentState);   
+        }
     }
 
     public void get(File localFile) throws DownloadException {

--- a/phoenicis-core/src/main/java/com/playonlinux/core/webservice/Webservice.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/webservice/Webservice.java
@@ -29,7 +29,7 @@ import org.apache.log4j.Logger;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.playonlinux.core.dto.DTO;
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
 import com.playonlinux.core.services.manager.Service;
 
@@ -41,7 +41,7 @@ public abstract class Webservice<T extends DTO> extends ObservableDefaultImpleme
     private final Semaphore updateSemaphore = new Semaphore(1);
 
     private List<T> items;
-    private ProgressStateEntity.State state = ProgressStateEntity.State.READY;
+    private ProgressEntity.State state = ProgressEntity.State.READY;
 
     public Webservice(URL url) {
         this.url = url;
@@ -50,7 +50,7 @@ public abstract class Webservice<T extends DTO> extends ObservableDefaultImpleme
     public synchronized void populate() {
         try {
             updateSemaphore.acquire();
-            this.state = ProgressStateEntity.State.PROGRESSING;
+            this.state = ProgressEntity.State.PROGRESSING;
             this.update();
 
             try {
@@ -58,13 +58,13 @@ public abstract class Webservice<T extends DTO> extends ObservableDefaultImpleme
                 final HTTPDownloader httpDownloader = new HTTPDownloader(this.url);
                 final String result = httpDownloader.get();
                 items = mapper.readValue(result, this.defineTypeReference());
-                this.state = ProgressStateEntity.State.SUCCESS;
+                this.state = ProgressEntity.State.SUCCESS;
             } catch (DownloadException e) {
                 LOGGER.warn(String.format("Error while downloading %s", url), e);
-                this.state = ProgressStateEntity.State.FAILED;
+                this.state = ProgressEntity.State.FAILED;
             } catch (IOException e) {
                 LOGGER.warn(String.format("IO error while downloading %s", url), e);
-                this.state = ProgressStateEntity.State.FAILED;
+                this.state = ProgressEntity.State.FAILED;
             } finally {
                 this.update();
             }
@@ -79,7 +79,7 @@ public abstract class Webservice<T extends DTO> extends ObservableDefaultImpleme
 
     private synchronized void update() {
         DownloadEnvelope<Collection<T>> envelopeDTO = new DownloadEnvelope<>();
-        ProgressStateEntity progressStateEntity = new ProgressStateEntity.Builder().withState(state).build();
+        ProgressEntity progressStateEntity = new ProgressEntity.Builder().withState(state).build();
 
         envelopeDTO.setDownloadState(progressStateEntity);
         envelopeDTO.setEnvelopeContent(items);

--- a/phoenicis-core/src/main/java/com/playonlinux/core/webservice/Webservice.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/core/webservice/Webservice.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.playonlinux.core.dto.DTO;
 import com.playonlinux.core.entities.ProgressEntity;
+import com.playonlinux.core.entities.ProgressState;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
 import com.playonlinux.core.services.manager.Service;
 
@@ -41,7 +42,7 @@ public abstract class Webservice<T extends DTO> extends ObservableDefaultImpleme
     private final Semaphore updateSemaphore = new Semaphore(1);
 
     private List<T> items;
-    private ProgressEntity.State state = ProgressEntity.State.READY;
+    private ProgressState state = ProgressState.READY;
 
     public Webservice(URL url) {
         this.url = url;
@@ -50,7 +51,7 @@ public abstract class Webservice<T extends DTO> extends ObservableDefaultImpleme
     public synchronized void populate() {
         try {
             updateSemaphore.acquire();
-            this.state = ProgressEntity.State.PROGRESSING;
+            this.state = ProgressState.PROGRESSING;
             this.update();
 
             try {
@@ -58,13 +59,13 @@ public abstract class Webservice<T extends DTO> extends ObservableDefaultImpleme
                 final HTTPDownloader httpDownloader = new HTTPDownloader(this.url);
                 final String result = httpDownloader.get();
                 items = mapper.readValue(result, this.defineTypeReference());
-                this.state = ProgressEntity.State.SUCCESS;
+                this.state = ProgressState.SUCCESS;
             } catch (DownloadException e) {
                 LOGGER.warn(String.format("Error while downloading %s", url), e);
-                this.state = ProgressEntity.State.FAILED;
+                this.state = ProgressState.FAILED;
             } catch (IOException e) {
                 LOGGER.warn(String.format("IO error while downloading %s", url), e);
-                this.state = ProgressEntity.State.FAILED;
+                this.state = ProgressState.FAILED;
             } finally {
                 this.update();
             }

--- a/phoenicis-core/src/main/java/com/playonlinux/engines/wine/DefaultWineVersionsManager.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/engines/wine/DefaultWineVersionsManager.java
@@ -128,17 +128,15 @@ public class DefaultWineVersionsManager
 
         final HTTPDownloader httpDownloader = new HTTPDownloader(packageUrl);
 
-        httpDownloader.addObserver(progressControl);
+        httpDownloader.setOnChange(progressControl);
         try {
             final File temporaryFile = File.createTempFile("wineVersion", "tar");
             temporaryFile.deleteOnExit();
             httpDownloader.get(temporaryFile);
-            httpDownloader.deleteObservers();
 
             final ChecksumCalculator checksumCalculator = new ChecksumCalculator();
-            checksumCalculator.addObserver(progressControl);
+            checksumCalculator.setOnChange(progressControl);
             final String clientSum = checksumCalculator.calculate(temporaryFile, "sha1");
-            checksumCalculator.deleteObservers();
             if(!clientSum.equals(serverSum)) {
                 throw new EngineInstallException(String.format("Error while downloading the file. Hash mismatch." +
                         System.lineSeparator() + System.lineSeparator() +
@@ -171,14 +169,12 @@ public class DefaultWineVersionsManager
     public void install(WineDistribution wineDistribution, Version version, File localFile, ProgressControl progressControl) throws EngineInstallException {
         final File extractPath = getExtractPath(wineDistribution, version);
         final Extractor extractor = new Extractor();
-        extractor.addObserver(progressControl);
+        extractor.setOnChange(progressControl);
 
         try {
             extractor.uncompress(localFile, extractPath);
         } catch (ArchiveException e) {
            throw new EngineInstallException("Unable to extract archive", e);
-        } finally {
-            extractor.deleteObservers();
         }
     }
 

--- a/phoenicis-core/src/main/java/com/playonlinux/engines/wine/DefaultWineVersionsManager.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/engines/wine/DefaultWineVersionsManager.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import com.playonlinux.app.PlayOnLinuxContext;
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 import com.playonlinux.core.observer.Observable;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
 import com.playonlinux.core.services.manager.ServiceInitializationException;
@@ -99,11 +99,11 @@ public class DefaultWineVersionsManager
     }
 
     public boolean isUpdating() {
-        return downloadEnvelope == null || downloadEnvelope.getDownloadState().getState() == ProgressStateEntity.State.PROGRESSING;
+        return downloadEnvelope == null || downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.PROGRESSING;
     }
 
     public boolean hasFailed() {
-        return downloadEnvelope.getDownloadState().getState() == ProgressStateEntity.State.FAILED;
+        return downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.FAILED;
     }
 
     private synchronized void refreshWebservice() throws ServiceInitializationException {

--- a/phoenicis-core/src/main/java/com/playonlinux/engines/wine/DefaultWineVersionsManager.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/engines/wine/DefaultWineVersionsManager.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import com.playonlinux.app.PlayOnLinuxContext;
-import com.playonlinux.core.entities.ProgressEntity;
+import com.playonlinux.core.entities.ProgressState;
 import com.playonlinux.core.observer.Observable;
 import com.playonlinux.core.observer.ObservableDefaultImplementation;
 import com.playonlinux.core.services.manager.ServiceInitializationException;
@@ -99,11 +99,11 @@ public class DefaultWineVersionsManager
     }
 
     public boolean isUpdating() {
-        return downloadEnvelope == null || downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.PROGRESSING;
+        return downloadEnvelope == null || downloadEnvelope.getDownloadState().getState() == ProgressState.PROGRESSING;
     }
 
     public boolean hasFailed() {
-        return downloadEnvelope.getDownloadState().getState() == ProgressEntity.State.FAILED;
+        return downloadEnvelope.getDownloadState().getState() == ProgressState.FAILED;
     }
 
     private synchronized void refreshWebservice() throws ServiceInitializationException {

--- a/phoenicis-core/src/main/java/com/playonlinux/engines/wine/packages/WinePackageProvider.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/engines/wine/packages/WinePackageProvider.java
@@ -29,6 +29,7 @@ import com.playonlinux.core.utils.ChecksumCalculator;
 import com.playonlinux.core.webservice.DownloadException;
 import com.playonlinux.core.webservice.HTTPDownloader;
 import com.playonlinux.engines.wine.EngineInstallException;
+import com.playonlinux.ui.api.ProgressControl;
 
 public class WinePackageProvider<T extends WinePackage> {
     private final T winePackage;
@@ -37,7 +38,7 @@ public class WinePackageProvider<T extends WinePackage> {
         this.winePackage = winePackage;
     }
 
-    public void installPackageForWineVersion(File extractPath, Observer progressControl) throws EngineInstallException {
+    public void installPackageForWineVersion(File extractPath, ProgressControl progressControl) throws EngineInstallException {
         final File destinationFile = new File(winePackage.getPackageDestination(), winePackage.getPackageFileName());
 
         if(!destinationFile.exists()) {
@@ -58,7 +59,7 @@ public class WinePackageProvider<T extends WinePackage> {
         }
     }
 
-    private void installPackageInLocalCache(Observer progressControl) throws EngineInstallException {
+    private void installPackageInLocalCache(ProgressControl progressControl) throws EngineInstallException {
         try {
             final URL packageUrl = winePackage.getPackageUrl();
             final HTTPDownloader httpDownloader = new HTTPDownloader(packageUrl);
@@ -66,14 +67,12 @@ public class WinePackageProvider<T extends WinePackage> {
             final File destinationFile = new File(destinationDirectory, winePackage.getPackageFileName());
             final String packageChecksum = winePackage.getPackageChecksum();
 
-            httpDownloader.addObserver(progressControl);
+            httpDownloader.setOnChange(progressControl);
             httpDownloader.get(destinationFile);
-            httpDownloader.deleteObservers();
 
             final ChecksumCalculator checksumCalculator = new ChecksumCalculator();
-            checksumCalculator.addObserver(progressControl);
+            checksumCalculator.setOnChange(progressControl);
             final String clientSum = checksumCalculator.calculate(destinationFile, "md5");
-            checksumCalculator.deleteObservers();
 
             if(!clientSum.equals(packageChecksum)) {
                 destinationFile.delete();

--- a/phoenicis-core/src/main/java/com/playonlinux/framework/Checksum.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/framework/Checksum.java
@@ -34,7 +34,7 @@ public class Checksum {
     public String md5(String file) throws IOException {
         com.playonlinux.core.utils.ChecksumCalculator checksumCalculatorCalculator = new com.playonlinux.core.utils.ChecksumCalculator();
         if(progressControl != null) {
-            checksumCalculatorCalculator.addObserver(progressControl);
+            checksumCalculatorCalculator.setOnChange(progressControl);
         }
         return checksumCalculatorCalculator.calculate(new File(file), "md5");
     }
@@ -42,7 +42,7 @@ public class Checksum {
     public String sha1(String file) throws IOException {
         com.playonlinux.core.utils.ChecksumCalculator checksumCalculatorCalculator = new com.playonlinux.core.utils.ChecksumCalculator();
         if(progressControl != null) {
-            checksumCalculatorCalculator.addObserver(progressControl);
+            checksumCalculatorCalculator.setOnChange(progressControl);
         }
         return checksumCalculatorCalculator.calculate(new File(file), "sha1");
     }

--- a/phoenicis-core/src/main/java/com/playonlinux/framework/Downloader.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/framework/Downloader.java
@@ -77,15 +77,13 @@ public class Downloader implements SetupWizardComponent {
 
         final HTTPDownloader downloader = new HTTPDownloader(remoteFile);
         try {
-            downloader.addObserver(progressControl);
+            downloader.setOnChange(progressControl);
             downloader.get(localFile);
         } catch (DownloadException e) {
             throw new ScriptFailureException(
                     String.format("Unable to download the file (Remote: %s, Local: %s)", remoteFile, localFile), e);
-        } finally {
-            downloader.deleteObserver(progressControl);
         }
-
+        
         downloadedFile = localFile;
         return this;
     }
@@ -124,7 +122,7 @@ public class Downloader implements SetupWizardComponent {
             ChecksumCalculator checksumCalculator = new ChecksumCalculator();
 
             if (progressControl != null) {
-                checksumCalculator.addObserver(progressControl);
+                checksumCalculator.setOnChange(progressControl);
             }
             calculatedChecksum = checksumCalculator.calculate(this.findDownloadedFile(), MD5_CHECKSUM);
         } catch (IOException e) {

--- a/phoenicis-core/src/main/java/com/playonlinux/ui/api/ProgressControl.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/ui/api/ProgressControl.java
@@ -18,14 +18,15 @@
 
 package com.playonlinux.ui.api;
 
+import java.util.function.Consumer;
+
 import com.playonlinux.core.entities.ProgressStateEntity;
 import com.playonlinux.core.observer.Observable;
-import com.playonlinux.core.observer.Observer;
 
 /**
  * Represents a progress control
  */
-public interface ProgressControl extends Observer<Observable, ProgressStateEntity> {
+public interface ProgressControl extends Consumer<ProgressStateEntity> {
     /**
      * Set the percentage of the progress bar
      * @param value The value to set
@@ -39,7 +40,7 @@ public interface ProgressControl extends Observer<Observable, ProgressStateEntit
     void setText(String text);
 
     @Override
-    default void update(Observable observable, ProgressStateEntity argument) {
+    default void accept(ProgressStateEntity argument) {
         setProgressPercentage(argument.getPercent());
         setText(argument.getProgressText());
     }

--- a/phoenicis-core/src/main/java/com/playonlinux/ui/api/ProgressControl.java
+++ b/phoenicis-core/src/main/java/com/playonlinux/ui/api/ProgressControl.java
@@ -20,13 +20,13 @@ package com.playonlinux.ui.api;
 
 import java.util.function.Consumer;
 
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 import com.playonlinux.core.observer.Observable;
 
 /**
  * Represents a progress control
  */
-public interface ProgressControl extends Consumer<ProgressStateEntity> {
+public interface ProgressControl extends Consumer<ProgressEntity> {
     /**
      * Set the percentage of the progress bar
      * @param value The value to set
@@ -40,7 +40,7 @@ public interface ProgressControl extends Consumer<ProgressStateEntity> {
     void setText(String text);
 
     @Override
-    default void accept(ProgressStateEntity argument) {
+    default void accept(ProgressEntity argument) {
         setProgressPercentage(argument.getPercent());
         setText(argument.getProgressText());
     }

--- a/phoenicis-javafx/src/main/java/com/playonlinux/javafx/setupwindow/StepRepresentationProgressBar.java
+++ b/phoenicis-javafx/src/main/java/com/playonlinux/javafx/setupwindow/StepRepresentationProgressBar.java
@@ -84,7 +84,7 @@ public class StepRepresentationProgressBar extends StepRepresentationMessage imp
 
 
     @Override
-    public void update(com.playonlinux.core.observer.Observable observable, ProgressStateEntity progressStateEntity) {
+    public void accept(ProgressStateEntity progressStateEntity) {
         this.setProgressPercentage(progressStateEntity.getPercent());
         this.setText(progressStateEntity.getProgressText());
     }

--- a/phoenicis-javafx/src/main/java/com/playonlinux/javafx/setupwindow/StepRepresentationProgressBar.java
+++ b/phoenicis-javafx/src/main/java/com/playonlinux/javafx/setupwindow/StepRepresentationProgressBar.java
@@ -18,7 +18,7 @@
 
 package com.playonlinux.javafx.setupwindow;
 
-import com.playonlinux.core.entities.ProgressStateEntity;
+import com.playonlinux.core.entities.ProgressEntity;
 import com.playonlinux.core.messages.AsynchroneousMessage;
 import com.playonlinux.core.messages.InterrupterSynchronousMessage;
 import com.playonlinux.core.messages.Message;
@@ -84,7 +84,7 @@ public class StepRepresentationProgressBar extends StepRepresentationMessage imp
 
 
     @Override
-    public void accept(ProgressStateEntity progressStateEntity) {
+    public void accept(ProgressEntity progressStateEntity) {
         this.setProgressPercentage(progressStateEntity.getPercent());
         this.setText(progressStateEntity.getProgressText());
     }


### PR DESCRIPTION
Use consumer instead of observer in HTTPDownloader.

It has impact on ProgressStateEntity and classes using it. ProgressStateEntity was renamed ProgressEntity and internal enum state was externalized in ProgressState.