### PR TITLE
fixed outputDirectory of assembly

### DIFF
--- a/phoenicis-dist/src/assembly/distribution.xml
+++ b/phoenicis-dist/src/assembly/distribution.xml
@@ -12,7 +12,7 @@
 			<includes>
 				<include>*</include>
 			</includes>
-			<outputDirectory>/</outputDirectory>
+			<outputDirectory></outputDirectory>
 		</fileSet>
 	</fileSets>
 	<moduleSets>


### PR DESCRIPTION
[WARNING] The assembly descriptor contains a filesystem-root relative
reference, which is not cross platform compatible /