### PR TITLE
No need for hacky workaround with java 8 path

### DIFF
--- a/phoenicis-dist/src/scripts/PlayOnLinux.sh
+++ b/phoenicis-dist/src/scripts/PlayOnLinux.sh
@@ -2,8 +2,4 @@
 POL_HOME=$(dirname $0)
 CLASSPATH=${CLASSPATH}:$POL_HOME/lib/*
 
-# Ensure path of Java 8 takes precedence on systems with Java 7 and 8 both installed
-# This is non-destructive and does not force users to set the default java env to Java 8
-export PATH=/usr/lib/jvm/java-8-openjdk/jre/bin/:$PATH
-
 java -classpath "$CLASSPATH" com.playonlinux.javafx.JavaFXApplication "$@"


### PR DESCRIPTION
Should be up to users to set their default java version

on Arch Linux, you could use the below to hotswap OpenJDK and Oracle JDK, but I haven't rigged it yet to be distro-agnostic

```
#!/bin/bash

POL_HOME=/opt/playonlinux5
CLASSPATH=${CLASSPATH}:$POL_HOME/lib/*

if [[ $(archlinux-java get | cut -d "-" -f2) >= 8 ]]; then
        export JAVA_HOME=$(archlinux-java get)
else
        export JAVA_HOME=$(ls /usr/lib/jvm/java-{8,9}-*/bin/javac 2>/dev/null | cut -d "/" -f-5 | head -1)
fi

java -classpath "$CLASSPATH" com.playonlinux.javafx.JavaFXApplication "$@"
```