### PR TITLE
Fixed problems with long app names

### DIFF
--- a/phoenicis-javafx/src/main/java/com/playonlinux/javafx/views/common/widget/MiniatureListWidget.java
+++ b/phoenicis-javafx/src/main/java/com/playonlinux/javafx/views/common/widget/MiniatureListWidget.java
@@ -23,6 +23,7 @@ import javafx.geometry.Pos;
 import javafx.scene.CacheHint;
 import javafx.scene.Node;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Pane;
@@ -130,6 +131,9 @@ public final class MiniatureListWidget extends ScrollPane {
 
             this.getChildren().add(miniature);
             this.getChildren().add(label);
+
+            final Tooltip tooltip = new Tooltip(appsItem);
+            Tooltip.install(miniature, tooltip);
 
         }
 

--- a/phoenicis-javafx/src/main/java/com/playonlinux/javafx/views/common/widget/MiniatureListWidget.java
+++ b/phoenicis-javafx/src/main/java/com/playonlinux/javafx/views/common/widget/MiniatureListWidget.java
@@ -22,6 +22,7 @@ import javafx.application.Platform;
 import javafx.geometry.Pos;
 import javafx.scene.CacheHint;
 import javafx.scene.Node;
+import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
@@ -125,8 +126,7 @@ public final class MiniatureListWidget extends ScrollPane {
             });
 
 
-            final Text label = new Text(appsItem);
-            label.setWrappingWidth(150);
+            final Label label = new Label(appsItem);
             label.getStyleClass().add("miniatureText");
 
             this.getChildren().add(miniature);


### PR DESCRIPTION
Fixes: Long game titles get shown incorrectly #431

- show tooltip when hovering app (might be wrapped)
- truncate app name if necessary