### PR TITLE
size app list with window size

### DIFF
--- a/phoenicis-javafx/src/main/java/com/playonlinux/javafx/views/common/widget/MiniatureListWidget.java
+++ b/phoenicis-javafx/src/main/java/com/playonlinux/javafx/views/common/widget/MiniatureListWidget.java
@@ -51,6 +51,8 @@ public final class MiniatureListWidget extends ScrollPane {
         this.setCache(true);
         this.setCacheHint(CacheHint.QUALITY);
 
+        this.content.prefWidthProperty().bind(this.widthProperty());
+
     }
 
     public static MiniatureListWidget create() {


### PR DESCRIPTION
The size of the app list is now adjusted with the window size.

small window:
![small](https://cloud.githubusercontent.com/assets/3973260/21741156/fa9a8730-d4cd-11e6-91d9-8039caa4ff27.png)

wide window:
![wide](https://cloud.githubusercontent.com/assets/3973260/21741159/162d780e-d4ce-11e6-93ea-1709909018dd.png)