### PR TITLE
Add i386 as possible value for property os.arch (fixes #426)

### DIFF
--- a/phoenicis-tools/src/main/java/com/playonlinux/tools/system/ArchitectureFetcher.java
+++ b/phoenicis-tools/src/main/java/com/playonlinux/tools/system/ArchitectureFetcher.java
@@ -36,7 +36,7 @@ public class ArchitectureFetcher {
         if(operatingSystemFetcher.fetchCurrentOperationSystem() == OperatingSystem.MACOSX) {
             return Architecture.AMD64;
         }
-        if("x86".equals(System.getProperty("os.arch"))) {
+        if("x86".equals(System.getProperty("os.arch")) || "i386".equals(System.getProperty("os.arch"))) {
             return Architecture.I386;
         } else {
             return Architecture.AMD64;


### PR DESCRIPTION
The property os.arch returns i386 and not x86 on 32bit Ubuntu (and possibly other Linux flavours).
Here is a screenshot to prove this:
![proof](https://cloud.githubusercontent.com/assets/8126341/22483583/271ff6da-e7fe-11e6-8be6-a6a67faa9052.png)
fixes #426 

(The screenshot and tests were done on Ubuntu 16.04 32bit)