### PR TITLE
first approach to create .deb

### DIFF
--- a/phoenicis-dist/pom.xml
+++ b/phoenicis-dist/pom.xml
@@ -26,6 +26,14 @@
 	</parent>
 	<artifactId>phoenicis-dist</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.playonlinux</groupId>
+            <artifactId>phoenicis-javafx</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -49,6 +57,53 @@
 					</execution>
 				</executions>
 			</plugin>
-		</plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>jdeb</artifactId>
+                <groupId>org.vafer</groupId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jdeb</goal>
+                        </goals>
+                        <configuration>
+                            <dataSet>
+                                <data>
+                                    <src>${basedir}/src/scripts/PlayOnLinux.sh</src>
+                                    <type>file</type>
+                                    <mapper>
+                                        <type>perm</type>
+                                        <prefix>/usr/share/phoenicis</prefix>
+                                    </mapper>
+                                </data>
+                                <data>
+                                    <src>${project.build.directory}/lib</src>
+                                    <type>directory</type>
+                                    <mapper>
+                                        <type>perm</type>
+                                        <prefix>/usr/share/phoenicis/lib</prefix>
+                                    </mapper>
+                                </data>
+                            </dataSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
 	</build>
 </project>

--- a/phoenicis-dist/src/deb/control/control
+++ b/phoenicis-dist/src/deb/control/control
@@ -1,0 +1,8 @@
+Package: Phoenicis
+Version: 5.0
+Section: games
+Priority: low
+Architecture: all
+Description: PlayOnLinux is a piece of software which allows you to easily install and use numerous games and apps designed to run with Microsoft® Windows®.
+Maintainer: some@mail.com
+Depends: default-jre | java8-runtime


### PR DESCRIPTION
see #551 

Just a first approach, still with several issues:
- uses phoenicis-dist, probably better in top level pom?
- installs to /usr/shar, should be split to /usr/local/lib and /usr/local/bin
- PlayOnLinux.sh is not executable after installation
- control file needs to be improved