### PR TITLE
Fixed link to building and simplified it

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This is the Phoenicis and PlayOnMac 5 repository.
 ## Scripts
 * Please make your pull request on this repository: https://github.com/Phoenicis/scripts to add scripts
 
-## Build instructions
-[Wiki: Building](https://github.com/Phoenicis/POL-POM-5/wiki/Building)
+## [Build instructions](https://github.com/Phoenicis/POL-POM-5/wiki/Build)
 
 ### Code Quality
 To keep code easier to maintain, please import the project specifics format and cleanup settings into your IDE


### PR DESCRIPTION
If you don't like having a link in the heading then just use the old format but fix it so it reads `[Wiki:Build](https://github.com/Phoenicis/POL-POM-5/wiki/Build)`

Also not sure why Code Quality is a lesser heading to Building (but haven't included that in the pull).