### PR TITLE
prepared generic engines (including install/delete)

### DIFF
--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/CombinedEnginesFilter.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/CombinedEnginesFilter.java
@@ -19,8 +19,9 @@
 package org.phoenicis.engines;
 
 
-import org.phoenicis.engines.dto.WineVersionDTO;
-import org.phoenicis.engines.dto.WineVersionDistributionDTO;
+import org.phoenicis.engines.dto.EngineCategoryDTO;
+import org.phoenicis.engines.dto.EngineSubCategoryDTO;
+import org.phoenicis.engines.dto.EngineVersionDTO;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -43,29 +44,36 @@ public class CombinedEnginesFilter {
         filters.add(filter);
     }
 
-    public void apply(List<WineVersionDistributionDTO> engines, String wineEnginesPath) {
-        List<WineVersionDistributionDTO> filteredDistributions = new ArrayList<>();
-        for (WineVersionDistributionDTO wineVersionDistributionDTO : engines) {
-            List<WineVersionDTO> filteredPackages = new ArrayList<>();
-            for (WineVersionDTO wineVersionDTO : wineVersionDistributionDTO.getPackages()) {
-                if (filters.contains(EnginesFilter.INSTALLED) && isInstalled(wineVersionDistributionDTO, wineVersionDTO, wineEnginesPath)) {
-                    filteredPackages.add(wineVersionDTO);
+    public void apply(List<EngineCategoryDTO> engines, String wineEnginesPath) {
+        List<EngineCategoryDTO> filteredCategories = new ArrayList<>();
+        for (EngineCategoryDTO engineCategoryDTO : engines) {
+            List<EngineSubCategoryDTO> filteredDistributions = new ArrayList<>();
+            for (EngineSubCategoryDTO engineSubCategoryDTO : engineCategoryDTO.getSubCategories()) {
+                List<EngineVersionDTO> filteredPackages = new ArrayList<>();
+                for (EngineVersionDTO engineVersionDTO : engineSubCategoryDTO.getPackages()) {
+                    if (filters.contains(EnginesFilter.INSTALLED) && isInstalled(engineSubCategoryDTO, engineVersionDTO, wineEnginesPath)) {
+                        filteredPackages.add(engineVersionDTO);
+                    }
+                    if (filters.contains(EnginesFilter.NOT_INSTALLED) && !isInstalled(engineSubCategoryDTO, engineVersionDTO, wineEnginesPath)) {
+                        filteredPackages.add(engineVersionDTO);
+                    }
                 }
-                if (filters.contains(EnginesFilter.NOT_INSTALLED) && !isInstalled(wineVersionDistributionDTO, wineVersionDTO, wineEnginesPath)) {
-                    filteredPackages.add(wineVersionDTO);
+                engineSubCategoryDTO.getPackages().clear();
+                engineSubCategoryDTO.getPackages().addAll(filteredPackages);
+                if (engineSubCategoryDTO.getPackages().isEmpty()) {
+                    filteredDistributions.add(engineSubCategoryDTO);
                 }
             }
-            wineVersionDistributionDTO.getPackages().clear();
-            wineVersionDistributionDTO.getPackages().addAll(filteredPackages);
-            if (wineVersionDistributionDTO.getPackages().isEmpty()) {
-                filteredDistributions.add(wineVersionDistributionDTO);
+            engineCategoryDTO.getSubCategories().removeAll(filteredDistributions);
+            if (engineCategoryDTO.getSubCategories().isEmpty()) {
+                filteredCategories.add(engineCategoryDTO);
             }
         }
-        engines.removeAll(filteredDistributions);
+        engines.removeAll(filteredCategories);
     }
 
-    private boolean isInstalled(WineVersionDistributionDTO wineVersionDistributionDTO, WineVersionDTO wineVersionDTO, String wineEnginesPath) {
-        File f = new File(wineEnginesPath + "/" + wineVersionDistributionDTO.getName() + "/" + wineVersionDTO.getVersion());
+    private boolean isInstalled(EngineSubCategoryDTO engineCategoryDTO, EngineVersionDTO engineVersionDTO, String wineEnginesPath) {
+        File f = new File(wineEnginesPath + "/" + engineCategoryDTO.getName() + "/" + engineVersionDTO.getVersion());
         return f.exists();
     }
 }

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/EnginesConfiguration.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/EnginesConfiguration.java
@@ -30,7 +30,7 @@ public class EnginesConfiguration {
     private ScriptsConfiguration scriptsConfiguration;
 
     @Bean
-    public WineVersionsManager wineVersionsFetcher() {
-        return new WineVersionsManager(scriptsConfiguration.scriptInterpreter(), new ObjectMapper());
+    public EnginesSource wineVersionsFetcher() {
+        return new EnginesSource(scriptsConfiguration.scriptInterpreter(), new ObjectMapper());
     }
 }

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineCategoryDTO.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineCategoryDTO.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2015-2017 PÂRIS Quentin
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package org.phoenicis.engines.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Represents a category of application
+ */
+@JsonDeserialize(builder = EngineCategoryDTO.Builder.class)
+public class EngineCategoryDTO {
+    private final String name;
+    private final String description;
+    private final List<EngineSubCategoryDTO> subCategories;
+    private String icon;
+
+    private EngineCategoryDTO(Builder builder) {
+        this.name = builder.name;
+        this.description = builder.description;
+        this.subCategories = Collections.unmodifiableList(builder.subCategories);
+        this.icon = builder.icon;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public List<EngineSubCategoryDTO> getSubCategories() {
+        return subCategories;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public static Comparator<EngineCategoryDTO> nameComparator() {
+        return (o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName());
+    }
+
+    @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
+    public static class Builder {
+        private String name;
+        private String description;
+        private List<EngineSubCategoryDTO> subCategories = new ArrayList<>();
+        private String icon;
+
+        public Builder() {
+            // Default constructor
+        }
+
+        public Builder(EngineCategoryDTO categoryDTO) {
+            this.withName(categoryDTO.getName())
+                    .withDescription(categoryDTO.getDescription())
+                    .withSubCategories(categoryDTO.getSubCategories())
+                    .withIcon(categoryDTO.getIcon());
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder withSubCategories(List<EngineSubCategoryDTO> subCategories) {
+            this.subCategories = subCategories;
+            return this;
+        }
+
+        public Builder withIcon(String iconPath) {
+            this.icon = iconPath;
+            return this;
+        }
+
+        public EngineCategoryDTO build() {
+            return new EngineCategoryDTO(this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append(name)
+                .toString();
+    }
+
+}

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineDTO.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineDTO.java
@@ -22,64 +22,59 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
-@JsonDeserialize(builder = WineEngineDTO.Builder.class)
-public class WineEngineDTO {
-    private final String architecture;
-    private final String distribution;
+import java.util.Map;
+
+@JsonDeserialize(builder = EngineDTO.Builder.class)
+public class EngineDTO {
+    private final String category;
+    private final String subCategory;
     private final String version;
-    private final String monoFile;
-    private final String geckoFile;
+    private final Map<String, String> userData;
 
-    private WineEngineDTO(Builder builder) {
-        architecture = builder.architecture;
-        distribution = builder.distribution;
+    private EngineDTO(Builder builder) {
+        category = builder.category;
+        subCategory = builder.subCategory;
         version = builder.version;
-        monoFile = builder.monoFile;
-        geckoFile = builder.geckoFile;
+        userData = builder.userData;
     }
 
-    public String getArchitecture() {
-        return architecture;
+    public String getCategory() {
+        return category;
     }
 
-    public String getDistribution() {
-        return distribution;
+    public String getSubCategory() {
+        return subCategory;
     }
 
     public String getVersion() {
         return version;
     }
 
-    public String getMonoFile() { return monoFile; }
-
-    public String getGeckoFile() { return geckoFile; }
+    public Map<String, String> getUserData() { return userData; }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(WineEngineDTO.class)
-                .append("architecture", architecture)
-                .append("distribution", distribution)
+        return new ToStringBuilder(EngineDTO.class)
+                .append("category", category)
+                .append("subCategory", subCategory)
                 .append("version", version)
-                .append("mono", monoFile)
-                .append("gecko", geckoFile)
                 .toString();
     }
 
     @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
     public static class Builder {
-        private String architecture;
-        private String distribution;
+        private String category;
+        private String subCategory;
         private String version;
-        private String monoFile;
-        private String geckoFile;
+        private Map<String, String> userData;
 
-        public Builder withArchitecture(String architecture) {
-            this.architecture = architecture;
+        public Builder withCategory(String category) {
+            this.category = category;
             return this;
         }
 
-        public Builder withDistribution(String distribution) {
-            this.distribution = distribution;
+        public Builder withSubCategory(String distribution) {
+            this.subCategory = distribution;
             return this;
         }
 
@@ -88,18 +83,13 @@ public class WineEngineDTO {
             return this;
         }
 
-        public Builder withMonoFile(String monoFile) {
-            this.monoFile = monoFile;
+        public Builder withUserData(Map<String, String> userData) {
+            this.userData = userData;
             return this;
         }
 
-        public Builder withGeckoFile(String geckoFile) {
-            this.geckoFile = geckoFile;
-            return this;
-        }
-
-        public WineEngineDTO build() {
-            return new WineEngineDTO(this);
+        public EngineDTO build() {
+            return new EngineDTO(this);
         }
 
     }

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineSubCategoryDTO.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineSubCategoryDTO.java
@@ -20,22 +20,22 @@ package org.phoenicis.engines.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.phoenicis.tools.version.Version;
 import org.phoenicis.tools.version.VersionComparator;
-import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.util.Comparator;
 import java.util.List;
 
-public class WineVersionDistributionDTO {
+public class EngineSubCategoryDTO {
     private final String name;
     private final String description;
-    private final List<WineVersionDTO> packages;
+    private final List<EngineVersionDTO> packages;
 
     @JsonCreator
-    public WineVersionDistributionDTO(@JsonProperty("name") String name,
-                                      @JsonProperty("description") String description,
-                                      @JsonProperty("packages") List<WineVersionDTO> packages) {
+    public EngineSubCategoryDTO(@JsonProperty("name") String name,
+                                @JsonProperty("description") String description,
+                                @JsonProperty("packages") List<EngineVersionDTO> packages) {
         this.name = name;
         this.description = description;
         this.packages = packages;
@@ -49,19 +49,19 @@ public class WineVersionDistributionDTO {
         return name;
     }
 
-    public List<WineVersionDTO> getPackages() {
+    public List<EngineVersionDTO> getPackages() {
         return packages;
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(WineVersionDistributionDTO.class)
+        return new ToStringBuilder(EngineSubCategoryDTO.class)
                 .append("name", name)
                 .append("description", description)
                 .append("packages", packages).toString();
     }
 
-    public static Comparator<WineVersionDTO> comparator() {
+    public static Comparator<EngineVersionDTO> comparator() {
         return (o1, o2) -> new VersionComparator().compare(
                 new Version(o1.getVersion()), new Version(o2.getVersion())
         );

--- a/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineVersionDTO.java
+++ b/phoenicis-engines/src/main/java/org/phoenicis/engines/dto/EngineVersionDTO.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
-@JsonDeserialize(builder = WineVersionDTO.Builder.class)
-public class WineVersionDTO {
+@JsonDeserialize(builder = EngineVersionDTO.Builder.class)
+public class EngineVersionDTO {
     private final String version;
     private final String url;
     private final String sha1sum;
@@ -34,7 +34,7 @@ public class WineVersionDTO {
     private final String monoFile;
     private final String geckoFile;
 
-    private WineVersionDTO(Builder builder) {
+    private EngineVersionDTO(Builder builder) {
         version = builder.version;
         url = builder.url;
         sha1sum = builder.sha1sum;
@@ -84,7 +84,7 @@ public class WineVersionDTO {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(WineVersionDTO.class)
+        return new ToStringBuilder(EngineVersionDTO.class)
                 .append("version", version)
                 .append("url", url)
                 .append("sha1sum", sha1sum)
@@ -152,8 +152,8 @@ public class WineVersionDTO {
             return this;
         }
 
-        public WineVersionDTO build() {
-            return new WineVersionDTO(this);
+        public EngineVersionDTO build() {
+            return new EngineVersionDTO(this);
         }
 
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
@@ -19,8 +19,8 @@
 package org.phoenicis.javafx.controller.engines;
 
 import javafx.application.Platform;
-import org.phoenicis.engines.WineVersionsManager;
-import org.phoenicis.engines.dto.WineEngineDTO;
+import org.phoenicis.engines.EnginesSource;
+import org.phoenicis.engines.dto.EngineDTO;
 import org.phoenicis.javafx.views.common.ConfirmMessage;
 import org.phoenicis.javafx.views.common.ErrorMessage;
 import org.phoenicis.javafx.views.mainwindow.engines.ViewEngines;
@@ -30,35 +30,35 @@ import java.util.function.Consumer;
 
 public class EnginesController {
     private final ViewEngines viewEngines;
-    private final WineVersionsManager wineVersionsManager;
+    private final EnginesSource enginesSource;
     private final String wineEnginesPath;
     private final ScriptInterpreter scriptInterpreter;
 
-    public EnginesController(ViewEngines viewEngines, WineVersionsManager wineVersionsManager, String wineEnginesPath, ScriptInterpreter scriptInterpreter) {
+    public EnginesController(ViewEngines viewEngines, EnginesSource enginesSource, String wineEnginesPath, ScriptInterpreter scriptInterpreter) {
         this.viewEngines = viewEngines;
-        this.wineVersionsManager = wineVersionsManager;
+        this.enginesSource = enginesSource;
         this.wineEnginesPath = wineEnginesPath;
         this.scriptInterpreter = scriptInterpreter;
 
         this.viewEngines.setOnApplyFilter(filter -> {
-            wineVersionsManager.fetchAvailableWineVersions(versions -> Platform.runLater(() -> {
+            enginesSource.fetchAvailableEngines(versions -> Platform.runLater(() -> {
                 filter.apply(versions, wineEnginesPath);
                 this.viewEngines.populate(versions, wineEnginesPath);
             }));
             this.viewEngines.showWineVersions();
         });
 
-        this.viewEngines.setOnInstallEngine(wineEngineDTO -> {
-            new ConfirmMessage("Install " + wineEngineDTO.getVersion(), "Are you sure you want to install " + wineEngineDTO.getVersion() + "?")
+        this.viewEngines.setOnInstallEngine(engineDTO -> {
+            new ConfirmMessage("Install " + engineDTO.getVersion(), "Are you sure you want to install " + engineDTO.getVersion() + "?")
                     .ask(() -> {
-                        installEngine(wineEngineDTO, e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
+                        installEngine(engineDTO, e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
                     });
         });
 
-        this.viewEngines.setOnDeleteEngine(wineEngineDTO -> {
-            new ConfirmMessage("Delete " + wineEngineDTO.getVersion(), "Are you sure you want to delete " + wineEngineDTO.getVersion() + "?")
+        this.viewEngines.setOnDeleteEngine(engineDTO -> {
+            new ConfirmMessage("Delete " + engineDTO.getVersion(), "Are you sure you want to delete " + engineDTO.getVersion() + "?")
             .ask(() -> {
-                deleteEngine(wineEngineDTO, e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
+                deleteEngine(engineDTO, e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
             });
         });
     }
@@ -68,11 +68,12 @@ public class EnginesController {
     }
 
     public void loadEngines() {
-        wineVersionsManager.fetchAvailableWineVersions(versions -> Platform.runLater(() -> this.viewEngines.populate(versions, wineEnginesPath)));
+        enginesSource.fetchAvailableEngines(versions -> Platform.runLater(() -> this.viewEngines.populate(versions, wineEnginesPath)));
+        this.viewEngines.setOnSelectCategory(categoryDTO -> this.viewEngines.populateEngines(categoryDTO.getName(), categoryDTO.getSubCategories(), wineEnginesPath));
         this.viewEngines.showWineVersions();
     }
 
-    private void installEngine(WineEngineDTO wineEngineDTO, Consumer<Exception> errorCallback) {
+    private void installEngine(EngineDTO engineDTO, Consumer<Exception> errorCallback) {
         /*final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
 
         interactiveScriptSession.eval("include([\"Functions\", \"Engines\", \"Wine\"]);",
@@ -80,9 +81,9 @@ public class EnginesController {
                         "new Wine()",
                         output -> {
                             final ScriptObjectMirror wine = (ScriptObjectMirror) output;
-                            wine.callMember("architecture", wineEngineDTO.getArchitecture());
-                            wine.callMember("distribution", wineEngineDTO.getDistribution());
-                            wine.callMember("version", wineEngineDTO.getVersion());
+                            wine.callMember("architecture", engineDTO.getCategory());
+                            wine.callMember("distribution", engineDTO.getDistribution());
+                            wine.callMember("version", engineDTO.getVersion());
                             wine.callMember("_installVersion");
                             wine.callMember("wait");
                         },
@@ -93,7 +94,7 @@ public class EnginesController {
         System.out.println("install Engine");
     }
 
-    private void deleteEngine(WineEngineDTO wineEngineDTO, Consumer<Exception> errorCallback) {
+    private void deleteEngine(EngineDTO engineDTO, Consumer<Exception> errorCallback) {
         // TODO
         System.out.println("delete Engine");
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
@@ -19,11 +19,13 @@
 package org.phoenicis.javafx.controller.engines;
 
 import javafx.application.Platform;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
 import org.phoenicis.engines.EnginesSource;
 import org.phoenicis.engines.dto.EngineDTO;
 import org.phoenicis.javafx.views.common.ConfirmMessage;
 import org.phoenicis.javafx.views.common.ErrorMessage;
 import org.phoenicis.javafx.views.mainwindow.engines.ViewEngines;
+import org.phoenicis.scripts.interpreter.InteractiveScriptSession;
 import org.phoenicis.scripts.interpreter.ScriptInterpreter;
 
 import java.util.function.Consumer;
@@ -74,28 +76,38 @@ public class EnginesController {
     }
 
     private void installEngine(EngineDTO engineDTO, Consumer<Exception> errorCallback) {
-        /*final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
+        final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
 
-        interactiveScriptSession.eval("include([\"Functions\", \"Engines\", \"Wine\"]);",
+        interactiveScriptSession.eval("include([\"Functions\", \"Engines\", \"" + engineDTO.getCategory() + "\"]);",
                 ignored -> interactiveScriptSession.eval(
                         "new Wine()",
                         output -> {
                             final ScriptObjectMirror wine = (ScriptObjectMirror) output;
-                            wine.callMember("architecture", engineDTO.getCategory());
-                            wine.callMember("distribution", engineDTO.getDistribution());
-                            wine.callMember("version", engineDTO.getVersion());
-                            wine.callMember("_installVersion");
-                            wine.callMember("wait");
+                            wine.callMember("install", engineDTO.getCategory()
+                                    , engineDTO.getSubCategory()
+                                    , engineDTO.getVersion()
+                                    , engineDTO.getUserData());
                         },
                         errorCallback),
                 errorCallback
-        );*/
-        // TODO
-        System.out.println("install Engine");
+        );
     }
 
     private void deleteEngine(EngineDTO engineDTO, Consumer<Exception> errorCallback) {
-        // TODO
-        System.out.println("delete Engine");
+        final InteractiveScriptSession interactiveScriptSession = scriptInterpreter.createInteractiveSession();
+
+        interactiveScriptSession.eval("include([\"Functions\", \"Engines\", \"" + engineDTO.getCategory() + "\"]);",
+                ignored -> interactiveScriptSession.eval(
+                        "new Wine()",
+                        output -> {
+                            final ScriptObjectMirror wine = (ScriptObjectMirror) output;
+                            wine.callMember("delete", engineDTO.getCategory()
+                                    , engineDTO.getSubCategory()
+                                    , engineDTO.getVersion()
+                                    , engineDTO.getUserData());
+                        },
+                        errorCallback),
+                errorCallback
+        );
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EnginePanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EnginePanel.java
@@ -22,12 +22,13 @@ import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.*;
-import org.phoenicis.engines.dto.WineEngineDTO;
+import org.phoenicis.engines.dto.EngineDTO;
 import org.phoenicis.javafx.views.common.ErrorMessage;
 import org.phoenicis.javafx.views.common.TextWithStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
 import static org.phoenicis.configuration.localisation.Localisation.translate;
@@ -36,16 +37,16 @@ final class EnginePanel extends VBox {
     private static final String CAPTION_TITLE_CSS_CLASS = "captionTitle";
     private static final String CONFIGURATION_PANE_CSS_CLASS = "containerConfigurationPane";
     private final Logger LOGGER = LoggerFactory.getLogger(EnginePanel.class);
-    private final WineEngineDTO wineEngineDTO;
+    private final EngineDTO engineDTO;
     private Node progress;
 
-    private Consumer<WineEngineDTO> onEngineInstall = (engine) -> {};
-    private Consumer<WineEngineDTO> onEngineDelete = (engine) -> {};
+    private Consumer<EngineDTO> onEngineInstall = (engine) -> {};
+    private Consumer<EngineDTO> onEngineDelete = (engine) -> {};
 
-    public EnginePanel(WineEngineDTO wineEngineDTO) {
+    public EnginePanel(EngineDTO engineDTO) {
         super();
         
-        this.wineEngineDTO = wineEngineDTO;
+        this.engineDTO = engineDTO;
 
         getStyleClass().add(CONFIGURATION_PANE_CSS_CLASS);
 
@@ -53,19 +54,18 @@ final class EnginePanel extends VBox {
         informationContentPane.getStyleClass().add("grid");
 
         informationContentPane.add(new TextWithStyle(translate("Version:"), CAPTION_TITLE_CSS_CLASS), 0, 0);
-        Label name = new Label(wineEngineDTO.getVersion());
+        Label name = new Label(engineDTO.getVersion());
         name.setWrapText(true);
         informationContentPane.add(name, 1, 0);
 
-        informationContentPane.add(new TextWithStyle(translate("Mono:"), CAPTION_TITLE_CSS_CLASS), 0, 1);
-        Label path = new Label(wineEngineDTO.getMonoFile());
-        path.setWrapText(true);
-        informationContentPane.add(path, 1, 1);
-
-        informationContentPane.add(new TextWithStyle(translate("Gecko:"), CAPTION_TITLE_CSS_CLASS), 0, 2);
-        Label version = new Label(wineEngineDTO.getGeckoFile());
-        version.setWrapText(true);
-        informationContentPane.add(version, 1, 2);
+        int rowIdx = 1;
+        for (Map.Entry<String, String> userData : engineDTO.getUserData().entrySet()) {
+            informationContentPane.add(new TextWithStyle(userData.getKey(), CAPTION_TITLE_CSS_CLASS), 0, rowIdx);
+            Label path = new Label(userData.getValue());
+            path.setWrapText(true);
+            informationContentPane.add(path, 1, rowIdx);
+            rowIdx++;
+        }
 
         informationContentPane.setHgap(20);
         informationContentPane.setVgap(10);
@@ -73,7 +73,7 @@ final class EnginePanel extends VBox {
         Button installButton = new Button("Install");
         installButton.setOnMouseClicked(evt -> {
             try {
-                onEngineInstall.accept(wineEngineDTO);
+                onEngineInstall.accept(engineDTO);
             } catch (IllegalArgumentException e) {
                 LOGGER.error("Failed to get engine", e);
                 new ErrorMessage("Error while trying to install the engine", e).show();
@@ -83,7 +83,7 @@ final class EnginePanel extends VBox {
         Button deleteButton = new Button("Delete");
         deleteButton.setOnMouseClicked(evt -> {
             try {
-                onEngineDelete.accept(wineEngineDTO);
+                onEngineDelete.accept(engineDTO);
             } catch (IllegalArgumentException e) {
                 LOGGER.error("Failed to get engine", e);
                 new ErrorMessage("Error while trying to delete the engine", e).show();
@@ -111,14 +111,14 @@ final class EnginePanel extends VBox {
         getChildren().add(progress);
     }
 
-    public void setOnEngineInstall(Consumer<WineEngineDTO> onEngineInstall) {
+    public void setOnEngineInstall(Consumer<EngineDTO> onEngineInstall) {
         this.onEngineInstall = onEngineInstall;
     }
-    public void setOnEngineDelete(Consumer<WineEngineDTO> onEngineDelete) {
+    public void setOnEngineDelete(Consumer<EngineDTO> onEngineDelete) {
         this.onEngineDelete = onEngineDelete;
     }
 
-    public WineEngineDTO getWineEngineDTO() {
-        return wineEngineDTO;
+    public EngineDTO getEngineDTO() {
+        return engineDTO;
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/scriptui/ProgressUiJavaFXImplementation.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/scriptui/ProgressUiJavaFXImplementation.java
@@ -35,15 +35,16 @@ public class ProgressUiJavaFXImplementation extends VBox implements ProgressUi, 
 
     public ProgressUiJavaFXImplementation() {
         super();
-    }
-
-    @Override
-    public void showProgressBar(Message<ProgressControl> message, String textToShow) {
         progressBar.setProgress(0.0);
         progressText.setId("stepText");
         progressBar.setPrefHeight(30);
         progressBar.prefWidthProperty().bind(this.widthProperty());
         this.getChildren().addAll(progressBar, progressText);
+    }
+
+    @Override
+    public void showProgressBar(Message<ProgressControl> message, String textToShow) {
+        progressBar.setProgress(0.0);
         message.send(this);
     }
 


### PR DESCRIPTION
Preparation for a generic engine handling as described in #620. 

Includes a generic install/delete.
- fixes #614
- fixes #615
- requires PlayOnLinux/Scripts#175

The EngineVersionDTO is not yet generic. It should contain an engine specific userData Map like EngineDTO. However, this requires a change in the Wine JSON format (Wine specific information like Mono/Gecko file should be contained in userData).