### PR TITLE
Fixing #634

### DIFF
--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/dark/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/dark/main.css
@@ -148,7 +148,7 @@
     -fx-font-size: 1.1em;
     -fx-alignment: baseline-left;
     -fx-translate-y: -0.1em;
-    -fx-fill: #FFFFFF;
+    -fx-text-fill: #FFFFFF;
 }
 
 .leftButton {


### PR DESCRIPTION
This should fix issue #634.
What I don't understand is, why `-fx-fill: #FFFFFF;` doesn't change the text color to white for the dark theme, because at least in my eyes it works for the Breeze Dark theme (`-fx-fill: #bdc3c7;`)