### PR TITLE
Fixing eclipse error message in pom files for the maven-java-formatter-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,14 +136,6 @@
                 <configuration>
                     <configFile>${project.basedir}/../settings/POL_Formatter_Settings.xml</configFile>
                 </configuration>
-
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>format</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR targets Issue #642 fixes the error messages visible in eclipse, that say:

> Plugin execution not covered by lifecycle configuration: com.googlecode.maven-java-formatter-plugin:maven-java-formatter-plugin:0.4:format (execution: default, phase: process-  sources)

The fix is done by removing the execution goal. Is this goal really needed? Running `mvn java-formatter:format` seems to format the code (at least I see a lot of skips because everything is formatted).

In addition I saw that we're using quite an old version of the maven-java-formatter plugin, does this have a reason?
The newest version seems to be 2.0.0 - 2.0.1 (as per https://github.com/revelc/formatter-maven-plugin).
