### PR TITLE
Fixing eclipse "Run as Java Application" error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,20 @@
 										<ignore></ignore>
 									</action>
 								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.codehaus.mojo</groupId>
+										<artifactId>buildnumber-maven-plugin</artifactId>
+										<versionRange>[1.4,)
+										</versionRange>
+										<goals>
+											<goal>create</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>										
+										<execute />
+									</action>
+								</pluginExecution>
 							</pluginExecutions>
 						</lifecycleMappingMetadata>
 					</configuration>


### PR DESCRIPTION
Fixing eclipse "Run as Java Application" error if the buildnumber-maven-plugin wasn't executed previously, as described in #641.