### PR TITLE
Using JGit to fetch GitApplicationsSources and caching them so they still exist after a restart of POL 5

### DIFF
--- a/phoenicis-apps/pom.xml
+++ b/phoenicis-apps/pom.xml
@@ -105,7 +105,11 @@
             <version>2.7.0</version>
         </dependency>
 
-
+		<dependency>
+		   	<groupId>org.eclipse.jgit</groupId>
+		   	<artifactId>org.eclipse.jgit</artifactId>
+			<version>4.6.1.201703071140-r</version>
+		</dependency>
 
     </dependencies>
 </project>

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/GitApplicationsSource.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/GitApplicationsSource.java
@@ -18,45 +18,109 @@
 
 package org.phoenicis.apps;
 
-import org.phoenicis.apps.dto.CategoryDTO;
-
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.RepositoryNotFoundException;
+import org.phoenicis.apps.dto.CategoryDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 class GitApplicationsSource implements ApplicationsSource {
-    private final String gitRepositoryURL;
-    private final LocalApplicationsSource.Factory localAppsSourceFactory;
-    private List<CategoryDTO> cache;
+	private final static Logger LOGGER = LoggerFactory.getLogger(GitApplicationsSource.class);
 
-    GitApplicationsSource(String gitRepositoryURL, LocalApplicationsSource.Factory localAppsSourceFactory) {
-        this.gitRepositoryURL = gitRepositoryURL;
-        this.localAppsSourceFactory = localAppsSourceFactory;
-    }
+	private final String gitRepositoryURL;
+	private final LocalApplicationsSource.Factory localAppsSourceFactory;
+	private List<CategoryDTO> cache;
 
-    @Override
-    public synchronized List<CategoryDTO> fetchInstallableApplications() {
-        if (cache != null) {
-            return cache;
-        }
+	private static final String cacheDirectoryPath = System.getProperty("java.io.tmpdir");
 
-        try {
-            final File gitTmp = Files.createTempDirectory("git").toFile();
-            gitTmp.deleteOnExit();
-            new ProcessBuilder(Arrays.asList("git", "clone", gitRepositoryURL, gitTmp.getAbsolutePath()))
-                    .inheritIO()
-                    .start()
-                    .waitFor();
+	GitApplicationsSource(String gitRepositoryURL, LocalApplicationsSource.Factory localAppsSourceFactory) {
+		this.gitRepositoryURL = gitRepositoryURL;
+		this.localAppsSourceFactory = localAppsSourceFactory;
+	}
 
-            cache = localAppsSourceFactory.createInstance(gitTmp.getAbsolutePath()).fetchInstallableApplications();
-            return cache;
-        } catch (IOException | InterruptedException e) {
-            return Collections.emptyList();
-        }
-    }
+	@Override
+	public synchronized List<CategoryDTO> fetchInstallableApplications() {
+		if (cache != null) {
+			return cache;
+		}
 
+		File gitRepositoryLocation = new File(
+				GitApplicationsSource.cacheDirectoryPath + "/git" + this.gitRepositoryURL.hashCode());
 
+		LOGGER.info(String.format("Git-repository '%s' will be saved in '%s'", this.gitRepositoryURL,
+				gitRepositoryLocation.getAbsolutePath()));
+
+		/*
+		 * This value is true if a folder for the git repository exists,
+		 * otherwise it is false
+		 */
+		boolean folderExists = true;
+
+		// check that the repository folder exists
+		if (!gitRepositoryLocation.exists()) {
+			folderExists = false;
+
+			LOGGER.info(String.format("Creating new folder '%s' for git-repository '%s'",
+					gitRepositoryLocation.getAbsolutePath(), this.gitRepositoryURL));
+
+			if (!gitRepositoryLocation.mkdir()) {
+				LOGGER.error(String.format("Couldn't create folder for git repository '%s' at '%s'",
+						this.gitRepositoryURL, gitRepositoryLocation.getAbsolutePath()));
+
+				return Collections.emptyList();
+			}
+		}
+
+		try {
+			Git gitRepository = null;
+
+			/*
+			 * if the repository folder previously didn't exist, clone the
+			 * repository now
+			 */
+			if (!folderExists) {
+				LOGGER.info(String.format("Cloning git-repository '%s' to '%s'", this.gitRepositoryURL, gitRepositoryLocation.getAbsolutePath()));
+
+				gitRepository = Git.cloneRepository().setURI(this.gitRepositoryURL).setDirectory(gitRepositoryLocation)
+						.call();
+			}
+			/*
+			 * otherwise open the folder and pull the newest updates from the
+			 * repository
+			 */
+			else {
+				LOGGER.info(String.format("Opening git-repository '%s' at '%s'", this.gitRepositoryURL,
+						gitRepositoryLocation.getAbsolutePath()));
+
+				gitRepository = Git.open(gitRepositoryLocation);
+
+				LOGGER.info(String.format("Pulling new commits from git-repository '%s' to '%s'", this.gitRepositoryURL,
+						gitRepositoryLocation.getAbsolutePath()));
+
+				gitRepository.pull().call();
+			}
+
+			// close repository to free resources
+			gitRepository.close();
+
+			this.cache = localAppsSourceFactory.createInstance(gitRepositoryLocation.getAbsolutePath())
+					.fetchInstallableApplications();
+		} catch (RepositoryNotFoundException | GitAPIException e) {
+			LOGGER.error(String.format("Folder '%s' is no git-repository", gitRepositoryLocation.getAbsolutePath()), e);
+
+			this.cache = Collections.emptyList();
+		} catch (IOException e) {
+			LOGGER.error(String.format("An unknown error occured.", e));
+
+			this.cache = Collections.emptyList();
+		}
+
+		return this.cache;
+	}
 }


### PR DESCRIPTION
This PR switched the ProcessBuilder approach of using git to clone the script repositories with a JGit approach that is written in pure java, as talked about in issue #650. 
In addition this approach clones the repositories in a cacheDirectory, which is currently still tmp, and doesn't delete the clones repository folders after application exit/termination. This enables POL 5 to just load the still existing local repository folders, without the need to clone them again, at the next startup of POL 5.

What's missing here is the correct folder, where the clones repositories are to be kept. If we let them stay in tmp, they are going to be deleted at system shutdown.