### PR TITLE
Changing the implementation of MultipleApplicationsSource to be parallel

### DIFF
--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/MergeableApplicationsSource.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/MergeableApplicationsSource.java
@@ -55,7 +55,7 @@ public interface MergeableApplicationsSource extends ApplicationsSource {
         leftApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
         rightApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
 
-        final List<byte[]> mergeMiniatures = new ArrayList();
+        final List<byte[]> mergeMiniatures = new ArrayList<>();
         mergeMiniaturesSet.forEach(miniature -> mergeMiniatures.add(miniature.array()));
 
         return new ApplicationDTO.Builder()

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/MergeableApplicationsSource.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/MergeableApplicationsSource.java
@@ -5,6 +5,7 @@ package org.phoenicis.apps;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -19,77 +20,128 @@ import org.phoenicis.apps.dto.CategoryDTO;
 import org.phoenicis.apps.dto.ResourceDTO;
 import org.phoenicis.apps.dto.ScriptDTO;
 
-public interface MergeableApplicationsSource extends ApplicationsSource {
-	public default CategoryDTO mergeCategories(CategoryDTO leftCategory, CategoryDTO rightCategory) {
-        final Map<String, ApplicationDTO> leftApplications = createSortedMap(leftCategory.getApplications(), ApplicationDTO::getName);
-        final Map<String, ApplicationDTO> rightApplications = createSortedMap(rightCategory.getApplications(), ApplicationDTO::getName);
+public abstract class MergeableApplicationsSource implements ApplicationsSource {
+	/**
+	 * This method merges multiple application sources into a single list of
+	 * category dtos. For this it receives a map, containing a binding between
+	 * all application sources and their category dto lists, and an array
+	 * containing all application sources that should be merged in the correct
+	 * order. While merging the application source it prioritizes a later
+	 * application source over an earlier one. This means, that if two
+	 * application sources contain the same script, the script from the later
+	 * application source is taken.
+	 * 
+	 * @param categoriesMap
+	 *            A map containing a binding between the application sources and
+	 *            their category dtos
+	 * @param applicationsSources
+	 *            A list containing all application sources in the order in
+	 *            which they should be merged
+	 * @return A list containing category dtos of the merged application
+	 *         sources. If no application sources were given, an empty list is
+	 *         returned
+	 */
+	protected List<CategoryDTO> mergeApplicationsSources(Map<ApplicationsSource, List<CategoryDTO>> categoriesMap,
+			ApplicationsSource... applicationsSources) {
+		int numberOfApplicationSources = applicationsSources.length;
 
-        final SortedMap<String, ApplicationDTO> mergedApps = new TreeMap<>(rightApplications);
+		if (numberOfApplicationSources == 0) {
+			return Collections.emptyList();
+		}
 
-        for (String applicationName : leftApplications.keySet()) {
-            final ApplicationDTO application = leftApplications.get(applicationName);
+		/*
+		 * Take the first application source, from behind, as the default one
+		 */
+		final Map<String, CategoryDTO> mergedCategories = createSortedMap(
+				categoriesMap.get(applicationsSources[numberOfApplicationSources - 1]), CategoryDTO::getName);
 
-            if (mergedApps.containsKey(applicationName)) {
-                mergedApps.put(applicationName, mergeApplications(mergedApps.get(applicationName), application));
-            } else {
-                mergedApps.put(applicationName, application);
-            }
-        }
+		for (int otherApplicationSourceIndex = numberOfApplicationSources
+				- 2; otherApplicationSourceIndex >= 0; otherApplicationSourceIndex--) {
+			final List<CategoryDTO> otherCategories = categoriesMap
+					.get(applicationsSources[otherApplicationSourceIndex]);
 
-        final List<ApplicationDTO> applications = new ArrayList<>(mergedApps.values());
-        applications.sort(ApplicationDTO.nameComparator());
-        return new CategoryDTO.Builder()
-                .withApplications(applications)
-                .withType(leftCategory.getType())
-                .withIcon(leftCategory.getIcon())
-                .withName(leftCategory.getName())
-                .build();
-    }
+			final Map<String, CategoryDTO> otherCategoriesMap = createSortedMap(otherCategories, CategoryDTO::getName);
 
-    public default ApplicationDTO mergeApplications(ApplicationDTO leftApplication,
-                                             ApplicationDTO rightApplication) {
-        final List<ScriptDTO> scripts = mergeListOfDtos(leftApplication.getScripts(), rightApplication.getScripts(), ScriptDTO::getName, ScriptDTO.nameComparator());
-        final List<ResourceDTO> resources = mergeListOfDtos(leftApplication.getResources(), rightApplication.getResources(), ResourceDTO::getName, ResourceDTO.nameComparator());
+			for (String categoryName : otherCategoriesMap.keySet()) {
+				final CategoryDTO category = otherCategoriesMap.get(categoryName);
 
-        final Set<ByteBuffer> mergeMiniaturesSet = new HashSet<>();
-        leftApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
-        rightApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
+				if (mergedCategories.containsKey(categoryName)) {
+					mergedCategories.put(categoryName, mergeCategories(mergedCategories.get(categoryName), category));
+				} else {
+					mergedCategories.put(categoryName, category);
+				}
+			}
+		}
 
-        final List<byte[]> mergeMiniatures = new ArrayList<>();
-        mergeMiniaturesSet.forEach(miniature -> mergeMiniatures.add(miniature.array()));
+		return new ArrayList<>(mergedCategories.values());
 
-        return new ApplicationDTO.Builder()
-                .withName(leftApplication.getName())
-                .withResources(resources)
-                .withScripts(scripts)
-                .withDescription(leftApplication.getDescription())
-                .withIcon(leftApplication.getIcon())
-                .withMiniatures(mergeMiniatures)
-                .build();
-    }
+	}
 
-    public default <T> List<T> mergeListOfDtos(List<T> leftList, List<T> rightList, Function<T, String> nameSupplier, Comparator<T> sorter) {
-        final Map<String, T> left = createSortedMap(leftList, nameSupplier);
-        final Map<String, T> right = createSortedMap(rightList, nameSupplier);
+	protected CategoryDTO mergeCategories(CategoryDTO leftCategory, CategoryDTO rightCategory) {
+		final Map<String, ApplicationDTO> leftApplications = createSortedMap(leftCategory.getApplications(),
+				ApplicationDTO::getName);
+		final Map<String, ApplicationDTO> rightApplications = createSortedMap(rightCategory.getApplications(),
+				ApplicationDTO::getName);
 
-        final SortedMap<String, T> merged = new TreeMap<>(left);
+		final SortedMap<String, ApplicationDTO> mergedApps = new TreeMap<>(rightApplications);
 
-        for (String name: right.keySet()) {
-            final T dto = right.get(name);
+		for (String applicationName : leftApplications.keySet()) {
+			final ApplicationDTO application = leftApplications.get(applicationName);
 
-            if (!merged.containsKey(name)) {
-                merged.put(name, dto);
-            }
-        }
+			if (mergedApps.containsKey(applicationName)) {
+				mergedApps.put(applicationName, mergeApplications(mergedApps.get(applicationName), application));
+			} else {
+				mergedApps.put(applicationName, application);
+			}
+		}
 
-        final List<T> result = new ArrayList<>(merged.values());
-        result.sort(sorter);
-        return result;
-    }
+		final List<ApplicationDTO> applications = new ArrayList<>(mergedApps.values());
+		applications.sort(ApplicationDTO.nameComparator());
+		return new CategoryDTO.Builder().withApplications(applications).withType(leftCategory.getType())
+				.withIcon(leftCategory.getIcon()).withName(leftCategory.getName()).build();
+	}
 
-    public default <T> Map<String, T> createSortedMap(List<T> dtos, Function<T, String> nameProvider) {
-        final SortedMap<String, T> map = new TreeMap<>();
-        dtos.forEach(dto -> map.put(nameProvider.apply(dto), dto));
-        return map;
-    }
+	protected ApplicationDTO mergeApplications(ApplicationDTO leftApplication, ApplicationDTO rightApplication) {
+		final List<ScriptDTO> scripts = mergeListOfDtos(leftApplication.getScripts(), rightApplication.getScripts(),
+				ScriptDTO::getName, ScriptDTO.nameComparator());
+		final List<ResourceDTO> resources = mergeListOfDtos(leftApplication.getResources(),
+				rightApplication.getResources(), ResourceDTO::getName, ResourceDTO.nameComparator());
+
+		final Set<ByteBuffer> mergeMiniaturesSet = new HashSet<>();
+		leftApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
+		rightApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
+
+		final List<byte[]> mergeMiniatures = new ArrayList<>();
+		mergeMiniaturesSet.forEach(miniature -> mergeMiniatures.add(miniature.array()));
+
+		return new ApplicationDTO.Builder().withName(leftApplication.getName()).withResources(resources)
+				.withScripts(scripts).withDescription(leftApplication.getDescription())
+				.withIcon(leftApplication.getIcon()).withMiniatures(mergeMiniatures).build();
+	}
+
+	protected <T> List<T> mergeListOfDtos(List<T> leftList, List<T> rightList, Function<T, String> nameSupplier,
+			Comparator<T> sorter) {
+		final Map<String, T> left = createSortedMap(leftList, nameSupplier);
+		final Map<String, T> right = createSortedMap(rightList, nameSupplier);
+
+		final SortedMap<String, T> merged = new TreeMap<>(left);
+
+		for (String name : right.keySet()) {
+			final T dto = right.get(name);
+
+			if (!merged.containsKey(name)) {
+				merged.put(name, dto);
+			}
+		}
+
+		final List<T> result = new ArrayList<>(merged.values());
+		result.sort(sorter);
+		return result;
+	}
+
+	protected <T> Map<String, T> createSortedMap(List<T> dtos, Function<T, String> nameProvider) {
+		final SortedMap<String, T> map = new TreeMap<>();
+		dtos.forEach(dto -> map.put(nameProvider.apply(dto), dto));
+		return map;
+	}
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/MergeableApplicationsSource.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/MergeableApplicationsSource.java
@@ -1,0 +1,95 @@
+/**
+ * 
+ */
+package org.phoenicis.apps;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+import org.phoenicis.apps.dto.ApplicationDTO;
+import org.phoenicis.apps.dto.CategoryDTO;
+import org.phoenicis.apps.dto.ResourceDTO;
+import org.phoenicis.apps.dto.ScriptDTO;
+
+public interface MergeableApplicationsSource extends ApplicationsSource {
+	public default CategoryDTO mergeCategories(CategoryDTO leftCategory, CategoryDTO rightCategory) {
+        final Map<String, ApplicationDTO> leftApplications = createSortedMap(leftCategory.getApplications(), ApplicationDTO::getName);
+        final Map<String, ApplicationDTO> rightApplications = createSortedMap(rightCategory.getApplications(), ApplicationDTO::getName);
+
+        final SortedMap<String, ApplicationDTO> mergedApps = new TreeMap<>(rightApplications);
+
+        for (String applicationName : leftApplications.keySet()) {
+            final ApplicationDTO application = leftApplications.get(applicationName);
+
+            if (mergedApps.containsKey(applicationName)) {
+                mergedApps.put(applicationName, mergeApplications(mergedApps.get(applicationName), application));
+            } else {
+                mergedApps.put(applicationName, application);
+            }
+        }
+
+        final List<ApplicationDTO> applications = new ArrayList<>(mergedApps.values());
+        applications.sort(ApplicationDTO.nameComparator());
+        return new CategoryDTO.Builder()
+                .withApplications(applications)
+                .withType(leftCategory.getType())
+                .withIcon(leftCategory.getIcon())
+                .withName(leftCategory.getName())
+                .build();
+    }
+
+    public default ApplicationDTO mergeApplications(ApplicationDTO leftApplication,
+                                             ApplicationDTO rightApplication) {
+        final List<ScriptDTO> scripts = mergeListOfDtos(leftApplication.getScripts(), rightApplication.getScripts(), ScriptDTO::getName, ScriptDTO.nameComparator());
+        final List<ResourceDTO> resources = mergeListOfDtos(leftApplication.getResources(), rightApplication.getResources(), ResourceDTO::getName, ResourceDTO.nameComparator());
+
+        final Set<ByteBuffer> mergeMiniaturesSet = new HashSet<>();
+        leftApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
+        rightApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
+
+        final List<byte[]> mergeMiniatures = new ArrayList();
+        mergeMiniaturesSet.forEach(miniature -> mergeMiniatures.add(miniature.array()));
+
+        return new ApplicationDTO.Builder()
+                .withName(leftApplication.getName())
+                .withResources(resources)
+                .withScripts(scripts)
+                .withDescription(leftApplication.getDescription())
+                .withIcon(leftApplication.getIcon())
+                .withMiniatures(mergeMiniatures)
+                .build();
+    }
+
+    public default <T> List<T> mergeListOfDtos(List<T> leftList, List<T> rightList, Function<T, String> nameSupplier, Comparator<T> sorter) {
+        final Map<String, T> left = createSortedMap(leftList, nameSupplier);
+        final Map<String, T> right = createSortedMap(rightList, nameSupplier);
+
+        final SortedMap<String, T> merged = new TreeMap<>(left);
+
+        for (String name: right.keySet()) {
+            final T dto = right.get(name);
+
+            if (!merged.containsKey(name)) {
+                merged.put(name, dto);
+            }
+        }
+
+        final List<T> result = new ArrayList<>(merged.values());
+        result.sort(sorter);
+        return result;
+    }
+
+    public default <T> Map<String, T> createSortedMap(List<T> dtos, Function<T, String> nameProvider) {
+        final SortedMap<String, T> map = new TreeMap<>();
+        dtos.forEach(dto -> map.put(nameProvider.apply(dto), dto));
+        return map;
+    }
+}

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/TeeApplicationsSource.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/TeeApplicationsSource.java
@@ -18,15 +18,14 @@
 
 package org.phoenicis.apps;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.phoenicis.apps.dto.CategoryDTO;
 
-public class TeeApplicationsSource implements MergeableApplicationsSource {
+public class TeeApplicationsSource extends MergeableApplicationsSource {
     private final ApplicationsSource leftApplicationSource;
     private final ApplicationsSource rightApplicationSource;
 
@@ -44,23 +43,10 @@ public class TeeApplicationsSource implements MergeableApplicationsSource {
 
     @Override
     public List<CategoryDTO> fetchInstallableApplications() {
-        final Map<String, CategoryDTO> leftCategories = createSortedMap(leftApplicationSource.fetchInstallableApplications(), CategoryDTO::getName);
-        final Map<String, CategoryDTO> rightCategories = createSortedMap(rightApplicationSource.fetchInstallableApplications(), CategoryDTO::getName);
-
-        final SortedMap<String, CategoryDTO> mergedCategories = new TreeMap<>(rightCategories);
-
-        for (String categoryName : leftCategories.keySet()) {
-            final CategoryDTO category = leftCategories.get(categoryName);
-
-            if (mergedCategories.containsKey(categoryName)) {
-                mergedCategories.put(categoryName, mergeCategories(mergedCategories.get(categoryName), category));
-            } else {
-                mergedCategories.put(categoryName, category);
-            }
-        }
-
-        return new ArrayList<>(mergedCategories.values());
+    	final Map<ApplicationsSource, List<CategoryDTO>> categoriesMap = Arrays.asList(leftApplicationSource, rightApplicationSource).stream()
+    			.collect(
+						Collectors.toMap(source -> source, ApplicationsSource::fetchInstallableApplications));
+    	
+    	return mergeApplicationsSources(categoriesMap, leftApplicationSource, rightApplicationSource);
     }
-
-    
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/TeeApplicationsSource.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/TeeApplicationsSource.java
@@ -18,16 +18,15 @@
 
 package org.phoenicis.apps;
 
-import org.phoenicis.apps.dto.ApplicationDTO;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
 import org.phoenicis.apps.dto.CategoryDTO;
-import org.phoenicis.apps.dto.ResourceDTO;
-import org.phoenicis.apps.dto.ScriptDTO;
 
-import java.nio.ByteBuffer;
-import java.util.*;
-import java.util.function.Function;
-
-public class TeeApplicationsSource implements ApplicationsSource {
+public class TeeApplicationsSource implements MergeableApplicationsSource {
     private final ApplicationsSource leftApplicationSource;
     private final ApplicationsSource rightApplicationSource;
 
@@ -63,78 +62,5 @@ public class TeeApplicationsSource implements ApplicationsSource {
         return new ArrayList<>(mergedCategories.values());
     }
 
-    private CategoryDTO mergeCategories(CategoryDTO leftCategory, CategoryDTO rightCategory) {
-        final Map<String, ApplicationDTO> leftApplications = createSortedMap(leftCategory.getApplications(), ApplicationDTO::getName);
-        final Map<String, ApplicationDTO> rightApplications = createSortedMap(rightCategory.getApplications(), ApplicationDTO::getName);
-
-        final SortedMap<String, ApplicationDTO> mergedApps = new TreeMap<>(rightApplications);
-
-        for (String applicationName : leftApplications.keySet()) {
-            final ApplicationDTO application = leftApplications.get(applicationName);
-
-            if (mergedApps.containsKey(applicationName)) {
-                mergedApps.put(applicationName, mergeApplications(mergedApps.get(applicationName), application));
-            } else {
-                mergedApps.put(applicationName, application);
-            }
-        }
-
-        final List<ApplicationDTO> applications = new ArrayList<>(mergedApps.values());
-        applications.sort(ApplicationDTO.nameComparator());
-        return new CategoryDTO.Builder()
-                .withApplications(applications)
-                .withType(leftCategory.getType())
-                .withIcon(leftCategory.getIcon())
-                .withName(leftCategory.getName())
-                .build();
-    }
-
-    private ApplicationDTO mergeApplications(ApplicationDTO leftApplication,
-                                             ApplicationDTO rightApplication) {
-        final List<ScriptDTO> scripts = mergeListOfDtos(leftApplication.getScripts(), rightApplication.getScripts(), ScriptDTO::getName, ScriptDTO.nameComparator());
-        final List<ResourceDTO> resources = mergeListOfDtos(leftApplication.getResources(), rightApplication.getResources(), ResourceDTO::getName, ResourceDTO.nameComparator());
-
-        final Set<ByteBuffer> mergeMiniaturesSet = new HashSet<>();
-        leftApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
-        rightApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
-
-        final List<byte[]> mergeMiniatures = new ArrayList();
-        mergeMiniaturesSet.forEach(miniature -> mergeMiniatures.add(miniature.array()));
-
-        return new ApplicationDTO.Builder()
-                .withName(leftApplication.getName())
-                .withResources(resources)
-                .withScripts(scripts)
-                .withDescription(leftApplication.getDescription())
-                .withIcon(leftApplication.getIcon())
-                .withMiniatures(mergeMiniatures)
-                .build();
-    }
-
-
-
-    private <T> List<T> mergeListOfDtos(List<T> leftList, List<T> rightList, Function<T, String> nameSupplier, Comparator<T> sorter) {
-        final Map<String, T> left = createSortedMap(leftList, nameSupplier);
-        final Map<String, T> right = createSortedMap(rightList, nameSupplier);
-
-        final SortedMap<String, T> merged = new TreeMap<>(left);
-
-        for (String name: right.keySet()) {
-            final T dto = right.get(name);
-
-            if (!merged.containsKey(name)) {
-                merged.put(name, dto);
-            }
-        }
-
-        final List<T> result = new ArrayList<>(merged.values());
-        result.sort(sorter);
-        return result;
-    }
-
-    private <T> Map<String, T> createSortedMap(List<T> dtos, Function<T, String> nameProvider) {
-        final SortedMap<String, T> map = new TreeMap<>();
-        dtos.forEach(dto -> map.put(nameProvider.apply(dto), dto));
-        return map;
-    }
+    
 }


### PR DESCRIPTION
This PR changes the implementation of MultipleApplicationsSource to be parallel through the use of the Java 8 Streaming API, see also #650. 
In addition this PR extracts the merging functionality of two `CategoryDTOs` from the `TeeApplicationsSource` class to a new interface called `MergeableApplicationsSource`, which enables this functionally to be directly used in `MultipleApplicationsSource`.