### PR TITLE
Added source information for scripts in the GUI

### DIFF
--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/GitApplicationsSource.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/GitApplicationsSource.java
@@ -59,7 +59,7 @@ class GitApplicationsSource implements ApplicationsSource {
 			LOGGER.info(String.format("Creating new folder '%s' for git-repository '%s'",
 					gitRepositoryLocation.getAbsolutePath(), this.gitRepositoryURL));
 
-			if (!gitRepositoryLocation.mkdir()) {
+			if (!gitRepositoryLocation.mkdirs()) {
 				LOGGER.error(String.format("Couldn't create folder for git repository '%s' at '%s'",
 						this.gitRepositoryURL, gitRepositoryLocation.getAbsolutePath()));
 

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/LocalApplicationsSource.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/LocalApplicationsSource.java
@@ -43,11 +43,18 @@ class LocalApplicationsSource implements ApplicationsSource {
     private final String repositoryDirectory;
     private final ObjectMapper objectMapper;
 
-    private LocalApplicationsSource(String repositoryDirectory, ObjectMapper objectMapper) {
+    private final String repositorySource;    
+
+    private LocalApplicationsSource(String repositoryDirectory, String repositorySource, ObjectMapper objectMapper) {
         this.repositoryDirectory = repositoryDirectory;
         this.objectMapper = objectMapper;
+        this.repositorySource = repositorySource;
     }
-
+    
+    private LocalApplicationsSource(String repositoryDirectory, ObjectMapper objectMapper) {
+        this(repositoryDirectory, repositoryDirectory, objectMapper);
+    }
+    
     @Override
     public List<CategoryDTO> fetchInstallableApplications() {
         final File repositoryDirectoryFile = new File(repositoryDirectory);
@@ -180,6 +187,8 @@ class LocalApplicationsSource implements ApplicationsSource {
                 final ScriptDTO.Builder scriptDTOBuilder = new ScriptDTO.Builder(
                         unSerializeScript(new File(scriptDirectory, "script.json")));
 
+                scriptDTOBuilder.withScriptSource(repositorySource);
+                
                 if (StringUtils.isBlank(scriptDTOBuilder.getScriptName())) {
                     scriptDTOBuilder.withScriptName(scriptDirectory.getName());
                 }
@@ -239,6 +248,10 @@ class LocalApplicationsSource implements ApplicationsSource {
 
         public LocalApplicationsSource createInstance(String path) {
             return new LocalApplicationsSource(path, objectMapper);
+        }
+        
+        public LocalApplicationsSource createInstance(String path, String source) {
+            return new LocalApplicationsSource(path, source, objectMapper);
         }
     }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/dto/ScriptDTO.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/dto/ScriptDTO.java
@@ -30,6 +30,7 @@ import java.util.List;
 @JsonDeserialize(builder = ScriptDTO.Builder.class)
 public class ScriptDTO {
     private final String scriptName;
+    private final String scriptSource;
     private final List<OperatingSystem> compatibleOperatingSystems;
     private final List<OperatingSystem> testingOperatingSystems;
     private final Boolean free;
@@ -38,6 +39,7 @@ public class ScriptDTO {
 
     private ScriptDTO(Builder builder) {
         this.scriptName = builder.scriptName;
+        this.scriptSource = builder.scriptSource;
         this.compatibleOperatingSystems = builder.compatibleOperatingSystems;
         this.testingOperatingSystems = builder.testingOperatingSystems;
         this.free = builder.free;
@@ -51,6 +53,10 @@ public class ScriptDTO {
 
     public String getName() {
         return scriptName;
+    }
+    
+    public String getScriptSource() {
+    	return scriptSource;
     }
 
     public List<OperatingSystem> getCompatibleOperatingSystems() {
@@ -80,6 +86,7 @@ public class ScriptDTO {
     @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
     public static class Builder {
         private String scriptName;
+        private String scriptSource;
         private List<OperatingSystem> compatibleOperatingSystems;
         private List<OperatingSystem> testingOperatingSystems;
         private Boolean free;
@@ -109,6 +116,11 @@ public class ScriptDTO {
             return this;
         }
 
+        public Builder withScriptSource(String scriptSource) {
+        	this.scriptSource = scriptSource;
+        	return this;
+        }
+        
         public Builder withCompatibleOperatingSystems(List<OperatingSystem> compatibleOperatingSystems) {
             this.compatibleOperatingSystems = compatibleOperatingSystems;
             return this;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
@@ -121,7 +121,8 @@ public class ControllerConfiguration {
         return new AppsController(
                 viewsConfiguration.viewApps(),
                 appsConfiguration.backgroundAppsSource(),
-                scriptsConfiguration.scriptInterpreter()
+                scriptsConfiguration.scriptInterpreter(),
+                settingsConfiguration.settingsManager()
         );
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
@@ -25,6 +25,7 @@ import org.phoenicis.apps.dto.CategoryDTO;
 import org.phoenicis.javafx.views.common.ErrorMessage;
 import org.phoenicis.javafx.views.mainwindow.apps.ViewApps;
 import org.phoenicis.scripts.interpreter.ScriptInterpreter;
+import org.phoenicis.settings.SettingsManager;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,16 +36,19 @@ public class AppsController {
     private final ViewApps view;
     private final ApplicationsSource appsSource;
     private final ScriptInterpreter scriptInterpreter;
-
+    private final SettingsManager settingsManager;
+    
     private Runnable onAppLoaded = () -> {};
 
     public AppsController(ViewApps view,
                           ApplicationsSource appsSource,
-                          ScriptInterpreter scriptInterpreter) {
+                          ScriptInterpreter scriptInterpreter,
+                          SettingsManager settingsManager) {
         this.view = view;
         this.appsSource = appsSource;
         this.scriptInterpreter = scriptInterpreter;
-
+        this.settingsManager = settingsManager;
+        
         this.view.setOnApplyFilter(filter -> {
             appsSource.setFilter(filter);
             appsSource.fetchInstallableApplications(
@@ -77,10 +81,10 @@ public class AppsController {
                 }
             }
             Collections.sort(allApps, Comparator.comparing(ApplicationDTO::getName));
-            this.view.populateApps(allApps);
+            this.view.populateApps(allApps, settingsManager);
         });
 
-        this.view.setOnSelectCategory(categoryDTO -> this.view.populateApps(categoryDTO.getApplications()));
+        this.view.setOnSelectCategory(categoryDTO -> this.view.populateApps(categoryDTO.getApplications(), settingsManager));
         this.view.setOnSelectScript(scriptDTO -> scriptInterpreter.runScript(
                 scriptDTO.getScript(),
                 e -> Platform.runLater(() -> {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/settings/SettingsController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/settings/SettingsController.java
@@ -30,7 +30,7 @@ public class SettingsController {
         this.view = view;
         this.settingsManager = settingsManager;
         this.view.setOnSave(settingsManager::save);
-        this.view.setSettings(this.settingsManager.load());
+        this.view.setSettings();
     }
 
     public ViewSettings getView() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/ViewsConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/ViewsConfiguration.java
@@ -30,6 +30,7 @@ import org.phoenicis.javafx.views.mainwindow.engines.ViewEngines;
 import org.phoenicis.javafx.views.mainwindow.library.ViewLibrary;
 import org.phoenicis.javafx.views.mainwindow.library.ViewsConfigurationLibrary;
 import org.phoenicis.javafx.views.mainwindow.settings.ViewSettings;
+import org.phoenicis.settings.SettingsConfiguration;
 import org.phoenicis.tools.ToolsConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -60,6 +61,9 @@ public class ViewsConfiguration {
 
     @Autowired
     private ToolsConfiguration toolsConfiguration;
+    
+    @Autowired
+    private SettingsConfiguration settingsConfiguration;
 
     @Bean
     public ViewApps viewApps() {
@@ -78,7 +82,7 @@ public class ViewsConfiguration {
 
     @Bean
     public ViewSettings viewSettings() {
-        return new ViewSettings(themeConfiguration.themeManager(), applicationName, applicationVersion, applicationGitRevision, applicationBuildTimestamp, toolsConfiguration.opener());
+        return new ViewSettings(themeConfiguration.themeManager(), applicationName, applicationVersion, applicationGitRevision, applicationBuildTimestamp, toolsConfiguration.opener(), settingsConfiguration.settingsManager());
     }
 
     @Bean

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/AppPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/AppPanel.java
@@ -31,6 +31,9 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import org.phoenicis.javafx.views.common.ThemeManager;
+import org.phoenicis.settings.Setting;
+import org.phoenicis.settings.Settings;
+import org.phoenicis.settings.SettingsManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +50,7 @@ final class AppPanel extends VBox {
 
     private Consumer<ScriptDTO> onScriptInstall = (script) -> {};
 
-    public AppPanel(ApplicationDTO applicationDTO, ThemeManager themeManager) {
+    public AppPanel(ApplicationDTO applicationDTO, ThemeManager themeManager, SettingsManager settingsManager) {
         super();
         this.getStyleClass().addAll("rightPane", "appPresentation");
         this.setPadding(new Insets(10));
@@ -67,7 +70,12 @@ final class AppPanel extends VBox {
         grid.setHgap(100);
         int row = 0;
         for (ScriptDTO script: applicationDTO.getScripts()) {
-            Label scriptName = new Label(String.format("%s (Source: %s)", script.getName(), script.getScriptSource()));
+        	Label scriptName;
+        	if (settingsManager.isViewScriptSource()) {
+        		scriptName = new Label(String.format("%s (Source: %s)", script.getName(), script.getScriptSource()));
+        	} else {
+        		scriptName = new Label(script.getName());
+        	}
             scriptName.getStyleClass().add("descriptionText");
             Button installButton = new Button("Install");
             installButton.setOnMouseClicked(evt -> {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/AppPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/AppPanel.java
@@ -67,7 +67,7 @@ final class AppPanel extends VBox {
         grid.setHgap(100);
         int row = 0;
         for (ScriptDTO script: applicationDTO.getScripts()) {
-            Label scriptName = new Label(script.getName());
+            Label scriptName = new Label(String.format("%s (Source: %s)", script.getName(), script.getScriptSource()));
             scriptName.getStyleClass().add("descriptionText");
             Button installButton = new Button("Install");
             installButton.setOnMouseClicked(evt -> {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ViewApps.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ViewApps.java
@@ -35,6 +35,8 @@ import org.phoenicis.javafx.views.common.ThemeManager;
 import org.phoenicis.javafx.views.common.widget.MiniatureListWidget;
 import org.phoenicis.javafx.views.mainwindow.MainWindowView;
 import org.phoenicis.javafx.views.mainwindow.ui.*;
+import org.phoenicis.settings.Settings;
+import org.phoenicis.settings.SettingsManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +127,7 @@ public class ViewApps extends MainWindowView {
         });
     }
 
-    public void populateApps(List<ApplicationDTO> applications) {
+    public void populateApps(List<ApplicationDTO> applications, SettingsManager settingsManager) {
         availableApps.clear();
 
         for (ApplicationDTO application : applications) {
@@ -136,7 +138,7 @@ public class ViewApps extends MainWindowView {
                 applicationItem = availableApps.addItem(application.getName(), application.getMiniatures().get(0));
             }
 
-            applicationItem.setOnMouseClicked(event -> this.showAppDetails(application));
+            applicationItem.setOnMouseClicked(event -> this.showAppDetails(application, settingsManager));
 
         }
     }
@@ -185,8 +187,8 @@ public class ViewApps extends MainWindowView {
         super.drawSideBar();
     }
 
-    private void showAppDetails(ApplicationDTO application) {
-        final AppPanel appPanel = new AppPanel(application, themeManager);
+    private void showAppDetails(ApplicationDTO application, SettingsManager settingsManager) {
+        final AppPanel appPanel = new AppPanel(application, themeManager, settingsManager);
         appPanel.setOnScriptInstall(this::installScript);
         showRightView(appPanel);
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
@@ -18,28 +18,7 @@
 
 package org.phoenicis.javafx.views.mainwindow.settings;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import javafx.event.ActionEvent;
-import javafx.geometry.Insets;
-import javafx.geometry.VPos;
-import javafx.scene.control.*;
-import javafx.scene.control.cell.TextFieldListCell;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.VBox;
-import javafx.scene.text.Text;
-import javafx.util.StringConverter;
-import org.phoenicis.javafx.views.common.TextWithStyle;
-import org.phoenicis.javafx.views.common.Theme;
-import org.phoenicis.javafx.views.common.ThemeManager;
-import org.phoenicis.javafx.views.mainwindow.MainWindowView;
-import org.phoenicis.javafx.views.mainwindow.MessagePanel;
-import org.phoenicis.javafx.views.mainwindow.ui.LeftGroup;
-import org.phoenicis.javafx.views.mainwindow.ui.LeftToggleButton;
-import org.phoenicis.settings.Setting;
-import org.phoenicis.settings.Settings;
-import org.phoenicis.tools.system.opener.Opener;
+import static org.phoenicis.configuration.localisation.Localisation.translate;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -47,264 +26,307 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 
-import static org.phoenicis.configuration.localisation.Localisation.translate;
+import org.phoenicis.javafx.views.common.TextWithStyle;
+import org.phoenicis.javafx.views.common.Theme;
+import org.phoenicis.javafx.views.common.ThemeManager;
+import org.phoenicis.javafx.views.mainwindow.MainWindowView;
+import org.phoenicis.javafx.views.mainwindow.MessagePanel;
+import org.phoenicis.javafx.views.mainwindow.ui.LeftGroup;
+import org.phoenicis.javafx.views.mainwindow.ui.LeftToggleButton;
+import org.phoenicis.settings.SettingsManager;
+import org.phoenicis.tools.system.opener.Opener;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.event.ActionEvent;
+import javafx.geometry.Insets;
+import javafx.geometry.VPos;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.TextInputDialog;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.control.cell.TextFieldListCell;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import javafx.util.StringConverter;
 
 public class ViewSettings extends MainWindowView {
-    private static final String CAPTION_TITLE_CSS_CLASS = "captionTitle";
-    private static final String CONFIGURATION_PANE_CSS_CLASS = "containerConfigurationPane";
-    private static final String TITLE_CSS_CLASS = "title";
-    private final String applicationName;
-    private final String applicationVersion;
-    private final String applicationGitRevision;
-    private final String applicationBuildTimestamp;
-    private final Opener opener;
-    private final ObservableList<String> repositories = FXCollections.observableArrayList();
-    private ComboBox<Theme> themes;
-    private Consumer<Settings> onSave;
-    private Settings settings = new Settings();
-    private MessagePanel selectSettingsPanel;
+	private static final String CAPTION_TITLE_CSS_CLASS = "captionTitle";
+	private static final String CONFIGURATION_PANE_CSS_CLASS = "containerConfigurationPane";
+	private static final String TITLE_CSS_CLASS = "title";
+	private final String applicationName;
+	private final String applicationVersion;
+	private final String applicationGitRevision;
+	private final String applicationBuildTimestamp;
+	private final Opener opener;
+	private final ObservableList<String> repositories = FXCollections.observableArrayList();
+	private ComboBox<Theme> themes;
+	private CheckBox showScriptSource;
+	private Runnable onSave;
+	private SettingsManager settingsManager;
+	private MessagePanel selectSettingsPanel;
 
-    private VBox uiPanel = new VBox();
-    private VBox repositoriesPanel = new VBox();
-    private VBox fileAssociationsPanel = new VBox();
-    private VBox networkPanel = new VBox();
-    private VBox aboutPanel = new VBox();
+	private VBox uiPanel = new VBox();
+	private VBox repositoriesPanel = new VBox();
+	private VBox fileAssociationsPanel = new VBox();
+	private VBox networkPanel = new VBox();
+	private VBox aboutPanel = new VBox();
 
-    public ViewSettings(ThemeManager themeManager, String applicationName, String applicationVersion, String applicationGitRevision, String applicationBuildTimestamp, Opener opener) {
-        super("Settings", themeManager);
-        this.applicationName = applicationName;
-        this.applicationVersion = applicationVersion;
-        this.applicationGitRevision = applicationGitRevision;
-        this.applicationBuildTimestamp = applicationBuildTimestamp;
-        this.opener = opener;
+	public ViewSettings(ThemeManager themeManager, String applicationName, String applicationVersion,
+			String applicationGitRevision, String applicationBuildTimestamp, Opener opener,
+			SettingsManager settingsManager) {
+		super("Settings", themeManager);
+		this.applicationName = applicationName;
+		this.applicationVersion = applicationVersion;
+		this.applicationGitRevision = applicationGitRevision;
+		this.applicationBuildTimestamp = applicationBuildTimestamp;
+		this.opener = opener;
+		this.settingsManager = settingsManager;
 
-        final List<LeftToggleButton> leftButtonList = new ArrayList<>();
-        ToggleGroup group = new ToggleGroup();
+		final List<LeftToggleButton> leftButtonList = new ArrayList<>();
+		ToggleGroup group = new ToggleGroup();
 
-        final LeftToggleButton uiButton = new LeftToggleButton("User Interface");
-        final String uiButtonIcon = "icons/mainwindow/settings/userInterface.png";
-        uiButton.setStyle("-fx-background-image: url('" + themeManager.getResourceUrl(uiButtonIcon) + "');");
-        uiButton.setToggleGroup(group);
-        leftButtonList.add(uiButton);
-        uiButton.setOnMouseClicked(event -> showRightView(uiPanel));
+		final LeftToggleButton uiButton = new LeftToggleButton("User Interface");
+		final String uiButtonIcon = "icons/mainwindow/settings/userInterface.png";
+		uiButton.setStyle("-fx-background-image: url('" + themeManager.getResourceUrl(uiButtonIcon) + "');");
+		uiButton.setToggleGroup(group);
+		leftButtonList.add(uiButton);
+		uiButton.setOnMouseClicked(event -> showRightView(uiPanel));
 
-        final LeftToggleButton repositoriesButton = new LeftToggleButton("Repositories");
-        final String repositoriesButtonIcon = "icons/mainwindow/settings/repository.png";
-        repositoriesButton.setStyle("-fx-background-image: url('" + themeManager.getResourceUrl(repositoriesButtonIcon) + "');");
-        repositoriesButton.setToggleGroup(group);
-        leftButtonList.add(repositoriesButton);
-        repositoriesButton.setOnMouseClicked(event -> showRightView(repositoriesPanel));
+		final LeftToggleButton repositoriesButton = new LeftToggleButton("Repositories");
+		final String repositoriesButtonIcon = "icons/mainwindow/settings/repository.png";
+		repositoriesButton
+				.setStyle("-fx-background-image: url('" + themeManager.getResourceUrl(repositoriesButtonIcon) + "');");
+		repositoriesButton.setToggleGroup(group);
+		leftButtonList.add(repositoriesButton);
+		repositoriesButton.setOnMouseClicked(event -> showRightView(repositoriesPanel));
 
-        final LeftToggleButton fileAssociationsButton = new LeftToggleButton("File Associations");
-        final String fileAssociationsButtonIcon = "icons/mainwindow/settings/settings.png";
-        fileAssociationsButton.setStyle("-fx-background-image: url('" + themeManager.getResourceUrl(fileAssociationsButtonIcon) + "');");
-        fileAssociationsButton.setToggleGroup(group);
-        leftButtonList.add(fileAssociationsButton);
-        fileAssociationsButton.setOnMouseClicked(event -> showRightView(fileAssociationsPanel));
+		final LeftToggleButton fileAssociationsButton = new LeftToggleButton("File Associations");
+		final String fileAssociationsButtonIcon = "icons/mainwindow/settings/settings.png";
+		fileAssociationsButton.setStyle(
+				"-fx-background-image: url('" + themeManager.getResourceUrl(fileAssociationsButtonIcon) + "');");
+		fileAssociationsButton.setToggleGroup(group);
+		leftButtonList.add(fileAssociationsButton);
+		fileAssociationsButton.setOnMouseClicked(event -> showRightView(fileAssociationsPanel));
 
-        final LeftToggleButton networkButton = new LeftToggleButton("Network");
-        final String networkButtonIcon = "icons/mainwindow/settings/network.png";
-        networkButton.setStyle("-fx-background-image: url('" + themeManager.getResourceUrl(networkButtonIcon) + "');");
-        networkButton.setToggleGroup(group);
-        leftButtonList.add(networkButton);
-        networkButton.setOnMouseClicked(event -> showRightView(networkPanel));
+		final LeftToggleButton networkButton = new LeftToggleButton("Network");
+		final String networkButtonIcon = "icons/mainwindow/settings/network.png";
+		networkButton.setStyle("-fx-background-image: url('" + themeManager.getResourceUrl(networkButtonIcon) + "');");
+		networkButton.setToggleGroup(group);
+		leftButtonList.add(networkButton);
+		networkButton.setOnMouseClicked(event -> showRightView(networkPanel));
 
-        final LeftToggleButton aboutButton = new LeftToggleButton("About");
-        final String aboutButtonIcon = "icons/mainwindow/settings/about.png";
-        aboutButton.setStyle("-fx-background-image: url('" + themeManager.getResourceUrl(aboutButtonIcon) + "');");
-        aboutButton.setToggleGroup(group);
-        leftButtonList.add(aboutButton);
-        aboutButton.setOnMouseClicked(event -> showRightView(aboutPanel));
+		final LeftToggleButton aboutButton = new LeftToggleButton("About");
+		final String aboutButtonIcon = "icons/mainwindow/settings/about.png";
+		aboutButton.setStyle("-fx-background-image: url('" + themeManager.getResourceUrl(aboutButtonIcon) + "');");
+		aboutButton.setToggleGroup(group);
+		leftButtonList.add(aboutButton);
+		aboutButton.setOnMouseClicked(event -> showRightView(aboutPanel));
 
-        final LeftGroup leftButtons = new LeftGroup("Settings");
-        leftButtons.setNodes(leftButtonList);
+		final LeftGroup leftButtons = new LeftGroup("Settings");
+		leftButtons.setNodes(leftButtonList);
 
-        addToSideBar(leftButtons);
-        super.drawSideBar();
+		addToSideBar(leftButtons);
+		super.drawSideBar();
 
-        initUiSettingsPane();
-        initRepositoriesSettingsPane();
-        initFileAssociationsPane();
-        initNetworkPane();
-        initAboutPane();
+		initUiSettingsPane();
+		initRepositoriesSettingsPane();
+		initFileAssociationsPane();
+		initNetworkPane();
+		initAboutPane();
 
-        initSelectSettingsPane();
-        showRightView(this.selectSettingsPanel);
-    }
+		initSelectSettingsPane();
+		showRightView(this.selectSettingsPanel);
+	}
 
-    private void initUiSettingsPane() {
-        uiPanel = new VBox();
-        uiPanel.getStyleClass().add(CONFIGURATION_PANE_CSS_CLASS);
+	private void initUiSettingsPane() {
+		uiPanel = new VBox();
+		uiPanel.getStyleClass().add(CONFIGURATION_PANE_CSS_CLASS);
 
-        final Text title = new TextWithStyle(translate("User Interface Settings"), TITLE_CSS_CLASS);
-        uiPanel.getChildren().add(title);
+		final Text title = new TextWithStyle(translate("User Interface Settings"), TITLE_CSS_CLASS);
+		uiPanel.getChildren().add(title);
 
-        final GridPane gridPane = new GridPane();
-        gridPane.getStyleClass().add("grid");
+		final GridPane gridPane = new GridPane();
+		gridPane.getStyleClass().add("grid");
 
-        gridPane.add(new TextWithStyle(translate("Theme:"), CAPTION_TITLE_CSS_CLASS), 0, 0);
-        themes = new ComboBox<>();
-        themes.getItems().setAll(Theme.values());
-        themes.setOnAction(event -> {
-            this.handleThemeChange(event);
-            this.save();}
-        );
-        gridPane.add(themes, 1, 0);
+		// Change Theme
+		gridPane.add(new TextWithStyle(translate("Theme:"), CAPTION_TITLE_CSS_CLASS), 0, 0);
+		themes = new ComboBox<>();
+		themes.getItems().setAll(Theme.values());
+		themes.setOnAction(event -> {
+			this.handleThemeChange(event);
+			this.save();
+		});
+		gridPane.add(themes, 1, 0);
 
-        gridPane.setHgap(20);
-        gridPane.setVgap(10);
+		// View Script Sources
+		showScriptSource = new CheckBox();
+		showScriptSource.setOnAction(event -> this.save());
+		gridPane.add(showScriptSource, 0, 1);
+		gridPane.add(new Label(translate("Select, if you want to view the source repository of the scripts")), 1, 1);
 
-        uiPanel.getChildren().add(gridPane);
+		gridPane.setHgap(20);
+		gridPane.setVgap(10);
 
-        final Label restartHint = new Label(translate("If you change the theme, please restart to load the icons of the new theme."));
-        restartHint.setPadding(new Insets(10));
-        uiPanel.getChildren().add(restartHint);
-    }
+		uiPanel.getChildren().add(gridPane);
 
-    private void initRepositoriesSettingsPane() {
-        repositoriesPanel = new VBox();
-        repositoriesPanel.getStyleClass().add(CONFIGURATION_PANE_CSS_CLASS);
+		final Label restartHint = new Label(
+				translate("If you change the theme, please restart to load the icons of the new theme."));
+		restartHint.setPadding(new Insets(10));
+		uiPanel.getChildren().add(restartHint);
+	}
 
-        final Text title = new TextWithStyle(translate("Repositories Settings"), TITLE_CSS_CLASS);
-        repositoriesPanel.getChildren().add(title);
+	private void initRepositoriesSettingsPane() {
+		repositoriesPanel = new VBox();
+		repositoriesPanel.getStyleClass().add(CONFIGURATION_PANE_CSS_CLASS);
 
-        final GridPane gridPane = new GridPane();
-        gridPane.getStyleClass().add("grid");
+		final Text title = new TextWithStyle(translate("Repositories Settings"), TITLE_CSS_CLASS);
+		repositoriesPanel.getChildren().add(title);
 
-        TextWithStyle repositoryText = new TextWithStyle(translate("Repository:"), CAPTION_TITLE_CSS_CLASS);
-        gridPane.add(repositoryText, 0, 0);
-        GridPane.setValignment(repositoryText, VPos.TOP);
-        VBox repositoryLayout = new VBox();
-        repositoryLayout.setSpacing(5);
-        ListView<String> repositoryListView = new ListView<>(repositories);
-        repositoryListView.setPrefSize(400, 100);
-        repositoryListView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
-        repositoryListView.setEditable(true);
-        repositoryListView.setCellFactory(param -> new TextFieldListCell<>(new StringConverter<String>() {
-            @Override
-            public String toString(String object) {
-                return object;
-            }
+		final GridPane gridPane = new GridPane();
+		gridPane.getStyleClass().add("grid");
 
-            @Override
-            public String fromString(String string) {
-                return string;
-            }
-        }));
-        HBox repositoryButtonLayout = new HBox();
-        repositoryButtonLayout.setSpacing(5);
-        Button addButton = new Button();
-        addButton.setText("Add");
-        addButton.setOnAction((ActionEvent event) -> {
-            TextInputDialog dialog = new TextInputDialog();
-            dialog.initOwner(getContent().getScene().getWindow());
-            dialog.setTitle("Add repository");
-            dialog.setHeaderText("Add repository");
-            dialog.setContentText("Please add the new repository:");
+		TextWithStyle repositoryText = new TextWithStyle(translate("Repository:"), CAPTION_TITLE_CSS_CLASS);
+		gridPane.add(repositoryText, 0, 0);
+		GridPane.setValignment(repositoryText, VPos.TOP);
+		VBox repositoryLayout = new VBox();
+		repositoryLayout.setSpacing(5);
+		ListView<String> repositoryListView = new ListView<>(repositories);
+		repositoryListView.setPrefSize(400, 100);
+		repositoryListView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+		repositoryListView.setEditable(true);
+		repositoryListView.setCellFactory(param -> new TextFieldListCell<>(new StringConverter<String>() {
+			@Override
+			public String toString(String object) {
+				return object;
+			}
 
-            Optional<String> result = dialog.showAndWait();
-            result.ifPresent(repositories::add);
-            this.save();
-        });
-        Button removeButton = new Button();
-        removeButton.setText("Remove");
-        removeButton.setOnAction((ActionEvent event) -> {
-            repositories.removeAll(repositoryListView.getSelectionModel().getSelectedItems());
-            this.save();
-        });
-        repositoryButtonLayout.getChildren().addAll(addButton, removeButton);
-        repositoryLayout.getChildren().addAll(repositoryListView, repositoryButtonLayout);
-        gridPane.add(repositoryLayout, 1, 0);
+			@Override
+			public String fromString(String string) {
+				return string;
+			}
+		}));
+		HBox repositoryButtonLayout = new HBox();
+		repositoryButtonLayout.setSpacing(5);
+		Button addButton = new Button();
+		addButton.setText("Add");
+		addButton.setOnAction((ActionEvent event) -> {
+			TextInputDialog dialog = new TextInputDialog();
+			dialog.initOwner(getContent().getScene().getWindow());
+			dialog.setTitle("Add repository");
+			dialog.setHeaderText("Add repository");
+			dialog.setContentText("Please add the new repository:");
 
-        gridPane.setHgap(20);
-        gridPane.setVgap(10);
+			Optional<String> result = dialog.showAndWait();
+			result.ifPresent(repositories::add);
+			this.save();
+		});
+		Button removeButton = new Button();
+		removeButton.setText("Remove");
+		removeButton.setOnAction((ActionEvent event) -> {
+			repositories.removeAll(repositoryListView.getSelectionModel().getSelectedItems());
+			this.save();
+		});
+		repositoryButtonLayout.getChildren().addAll(addButton, removeButton);
+		repositoryLayout.getChildren().addAll(repositoryListView, repositoryButtonLayout);
+		gridPane.add(repositoryLayout, 1, 0);
 
-        repositoriesPanel.getChildren().add(gridPane);
-    }
+		gridPane.setHgap(20);
+		gridPane.setVgap(10);
 
-    private void initFileAssociationsPane() {
+		repositoriesPanel.getChildren().add(gridPane);
+	}
 
-    }
+	private void initFileAssociationsPane() {
 
-    private void initNetworkPane() {
+	}
 
-    }
+	private void initNetworkPane() {
 
-    private void initAboutPane() {
-        aboutPanel = new VBox();
-        aboutPanel.getStyleClass().add(CONFIGURATION_PANE_CSS_CLASS);
+	}
 
-        final Text title = new TextWithStyle(translate("About"), TITLE_CSS_CLASS);
-        aboutPanel.getChildren().add(title);
+	private void initAboutPane() {
+		aboutPanel = new VBox();
+		aboutPanel.getStyleClass().add(CONFIGURATION_PANE_CSS_CLASS);
 
-        final GridPane gridPane = new GridPane();
-        gridPane.getStyleClass().add("grid");
+		final Text title = new TextWithStyle(translate("About"), TITLE_CSS_CLASS);
+		aboutPanel.getChildren().add(title);
 
-        gridPane.add(new TextWithStyle(translate("Name:"), CAPTION_TITLE_CSS_CLASS), 0, 0);
-        gridPane.add(new Label(applicationName), 1, 0);
+		final GridPane gridPane = new GridPane();
+		gridPane.getStyleClass().add("grid");
 
-        gridPane.add(new TextWithStyle(translate("Version:"), CAPTION_TITLE_CSS_CLASS), 0, 1);
-        gridPane.add(new Label(applicationVersion), 1, 1);
+		gridPane.add(new TextWithStyle(translate("Name:"), CAPTION_TITLE_CSS_CLASS), 0, 0);
+		gridPane.add(new Label(applicationName), 1, 0);
 
-        gridPane.add(new TextWithStyle(translate("Git Revision:"), CAPTION_TITLE_CSS_CLASS), 0, 2);
-        Hyperlink gitRevisionLink = new Hyperlink(applicationGitRevision);
-        gitRevisionLink.setOnAction(event ->
-                {
-                    try {
-                        URI uri = new URI("https://github.com/PlayOnLinux/POL-POM-5/commit/" + applicationGitRevision);
-                        opener.open(uri);
-                    } catch (URISyntaxException e) {
-                        e.printStackTrace();
-                    }
-                }
-        );
-        gridPane.add(gitRevisionLink, 1, 2);
+		gridPane.add(new TextWithStyle(translate("Version:"), CAPTION_TITLE_CSS_CLASS), 0, 1);
+		gridPane.add(new Label(applicationVersion), 1, 1);
 
-        gridPane.add(new TextWithStyle(translate("Build Timestamp:"), CAPTION_TITLE_CSS_CLASS), 0, 3);
-        gridPane.add(new Label(applicationBuildTimestamp), 1, 3);
+		gridPane.add(new TextWithStyle(translate("Git Revision:"), CAPTION_TITLE_CSS_CLASS), 0, 2);
+		Hyperlink gitRevisionLink = new Hyperlink(applicationGitRevision);
+		gitRevisionLink.setOnAction(event -> {
+			try {
+				URI uri = new URI("https://github.com/PlayOnLinux/POL-POM-5/commit/" + applicationGitRevision);
+				opener.open(uri);
+			} catch (URISyntaxException e) {
+				e.printStackTrace();
+			}
+		});
+		gridPane.add(gitRevisionLink, 1, 2);
 
-        gridPane.setHgap(20);
-        gridPane.setVgap(10);
+		gridPane.add(new TextWithStyle(translate("Build Timestamp:"), CAPTION_TITLE_CSS_CLASS), 0, 3);
+		gridPane.add(new Label(applicationBuildTimestamp), 1, 3);
 
-        aboutPanel.getChildren().add(gridPane);
-    }
+		gridPane.setHgap(20);
+		gridPane.setVgap(10);
 
-    public void setSettings(Settings settings) {
-        final Theme setTheme = Theme.fromShortName(settings.get(Setting.THEME));
-        themes.setValue(setTheme);
+		aboutPanel.getChildren().add(gridPane);
+	}
 
-        repositories.addAll(settings.get(Setting.REPOSITORY).split(";"));
-    }
+	public void setSettings() {
+		final Theme setTheme = Theme.fromShortName(settingsManager.getTheme());
+		themes.setValue(setTheme);
 
-    public void setOnSave(Consumer<Settings> onSave) {
-        this.onSave = onSave;
-    }
+		showScriptSource.setSelected(settingsManager.isViewScriptSource());
 
-    private void initSelectSettingsPane() {
-        this.selectSettingsPanel = new MessagePanel(translate("Please select a settings category"));
-    }
+		repositories.addAll(settingsManager.getRepository().split(";"));
+	}
 
-    private void save() {
-        settings.set(Setting.THEME, themes.getSelectionModel().getSelectedItem().getShortName());
+	public void setOnSave(Runnable onSave) {
+		this.onSave = onSave;
+	}
 
-        StringBuilder stringBuilder = new StringBuilder();
-        for (String repository : repositories) {
-            stringBuilder.append(repository).append(";");
-        }
-        settings.set(Setting.REPOSITORY, stringBuilder.toString());
+	private void initSelectSettingsPane() {
+		this.selectSettingsPanel = new MessagePanel(translate("Please select a settings category"));
+	}
 
-        onSave.accept(this.settings);
-    }
+	private void save() {
+		settingsManager.setTheme(themes.getSelectionModel().getSelectedItem().getShortName());
+		settingsManager.setViewScriptSource(showScriptSource.isSelected());
 
-    private void handleThemeChange(ActionEvent evt) {
-        final Theme theme = themes.getSelectionModel().getSelectedItem();
-        themeManager.setCurrentTheme(theme);
-        final String shortName = theme.getShortName();
-        final String url = String.format("/org/phoenicis/javafx/themes/%s/main.css", shortName);
-        final URL style = this.getClass().getResource(url);
-        getContent().getScene().getStylesheets().clear();
-        getContent().getScene().getStylesheets().add(style.toExternalForm());
-    }
+		StringBuilder stringBuilder = new StringBuilder();
+		for (String repository : repositories) {
+			stringBuilder.append(repository).append(";");
+		}
+		settingsManager.setRepository(stringBuilder.toString());
+
+		onSave.run();
+	}
+
+	private void handleThemeChange(ActionEvent evt) {
+		final Theme theme = themes.getSelectionModel().getSelectedItem();
+		themeManager.setCurrentTheme(theme);
+		final String shortName = theme.getShortName();
+		final String url = String.format("/org/phoenicis/javafx/themes/%s/main.css", shortName);
+		final URL style = this.getClass().getResource(url);
+		getContent().getScene().getStylesheets().clear();
+		getContent().getScene().getStylesheets().add(style.toExternalForm());
+	}
 }

--- a/phoenicis-settings/src/main/java/org/phoenicis/settings/Setting.java
+++ b/phoenicis-settings/src/main/java/org/phoenicis/settings/Setting.java
@@ -20,6 +20,7 @@ package org.phoenicis.settings;
 
 public enum Setting {
     THEME("application.theme"),
+    VIEW_SOURCE("application.viewsource"),
     REPOSITORY("application.repository.configuration");
 
     private final String propertyName;

--- a/phoenicis-settings/src/main/java/org/phoenicis/settings/SettingsManager.java
+++ b/phoenicis-settings/src/main/java/org/phoenicis/settings/SettingsManager.java
@@ -18,7 +18,6 @@
 
 package org.phoenicis.settings;
 
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.util.DefaultPropertiesPersister;
 
@@ -28,21 +27,21 @@ import java.io.OutputStream;
 
 public class SettingsManager {
 	@Value("${application.theme}")
-    private String theme;
-    
-    @Value("${application.viewsource}")
-    private boolean viewScriptSource;
+	private String theme;
 
-    @Value("${application.repository.configuration}")
-    private String repository;
+	@Value("${application.viewsource}")
+	private boolean viewScriptSource;
 
-    private String settingsFileName = "config.properties";
+	@Value("${application.repository.configuration}")
+	private String repository;
 
-    public SettingsManager(String settingsFileName) {
-        this.settingsFileName = settingsFileName;
-    }
-    
-    public String getTheme() {
+	private String settingsFileName = "config.properties";
+
+	public SettingsManager(String settingsFileName) {
+		this.settingsFileName = settingsFileName;
+	}
+
+	public String getTheme() {
 		return theme;
 	}
 
@@ -66,23 +65,23 @@ public class SettingsManager {
 		this.repository = repository;
 	}
 
-    public void save() {
-    	Settings settings = load();
-        try {
-            File file = new File(settingsFileName);
-            OutputStream outputStream = new FileOutputStream(file);
-            DefaultPropertiesPersister persister = new DefaultPropertiesPersister();
-            persister.store(settings.getProperties(), outputStream, "PoL 5 User Settings");
-        } catch (Exception e ) {
-            e.printStackTrace();
-        }
-    }
+	public void save() {
+		Settings settings = load();
+		try {
+			File file = new File(settingsFileName);
+			OutputStream outputStream = new FileOutputStream(file);
+			DefaultPropertiesPersister persister = new DefaultPropertiesPersister();
+			persister.store(settings.getProperties(), outputStream, "PoL 5 User Settings");
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
 
-    private Settings load() {
-        Settings settings = new Settings();
-        settings.set(Setting.THEME, theme);
-        settings.set(Setting.VIEW_SOURCE, String.valueOf(viewScriptSource));
-        settings.set(Setting.REPOSITORY, repository);
-        return settings;
-    }
+	private Settings load() {
+		Settings settings = new Settings();
+		settings.set(Setting.THEME, theme);
+		settings.set(Setting.VIEW_SOURCE, String.valueOf(viewScriptSource));
+		settings.set(Setting.REPOSITORY, repository);
+		return settings;
+	}
 }

--- a/phoenicis-settings/src/main/java/org/phoenicis/settings/SettingsManager.java
+++ b/phoenicis-settings/src/main/java/org/phoenicis/settings/SettingsManager.java
@@ -27,8 +27,11 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 
 public class SettingsManager {
-    @Value("${application.theme}")
+	@Value("${application.theme}")
     private String theme;
+    
+    @Value("${application.viewsource}")
+    private boolean viewScriptSource;
 
     @Value("${application.repository.configuration}")
     private String repository;
@@ -38,8 +41,33 @@ public class SettingsManager {
     public SettingsManager(String settingsFileName) {
         this.settingsFileName = settingsFileName;
     }
+    
+    public String getTheme() {
+		return theme;
+	}
 
-    public void save(Settings settings) {
+	public void setTheme(String theme) {
+		this.theme = theme;
+	}
+
+	public boolean isViewScriptSource() {
+		return viewScriptSource;
+	}
+
+	public void setViewScriptSource(boolean viewScriptSource) {
+		this.viewScriptSource = viewScriptSource;
+	}
+
+	public String getRepository() {
+		return repository;
+	}
+
+	public void setRepository(String repository) {
+		this.repository = repository;
+	}
+
+    public void save() {
+    	Settings settings = load();
         try {
             File file = new File(settingsFileName);
             OutputStream outputStream = new FileOutputStream(file);
@@ -50,9 +78,10 @@ public class SettingsManager {
         }
     }
 
-    public Settings load() {
+    private Settings load() {
         Settings settings = new Settings();
         settings.set(Setting.THEME, theme);
+        settings.set(Setting.VIEW_SOURCE, String.valueOf(viewScriptSource));
         settings.set(Setting.REPOSITORY, repository);
         return settings;
     }


### PR DESCRIPTION
This PR adds source information to the scripts in the GUI, according to #656:
![grafik](https://cloud.githubusercontent.com/assets/18488086/24013078/8951efa8-0a80-11e7-8cf5-d010cb81a69c.png)
While doing this, I've also removed the cache variable from `GitApplicationsSource`, because we're using `CachedApplicationsSource` for caching purposes.