### PR TITLE
Bugfix: Added missing default values for the viewsources property

### DIFF
--- a/phoenicis-configuration/src/main/resources/Linux.properties
+++ b/phoenicis-configuration/src/main/resources/Linux.properties
@@ -21,6 +21,7 @@ application.version                         =           ${project.version}
 application.gitRevision                     =           ${buildNumber}
 application.buildTimestamp                  =           ${timestamp}
 application.theme                           =           default
+application.viewsource                      =           false
 
 application.user.root                       =           ${user.home}/.Phoenicis
 application.user.desktopShortcuts           =           ${user.home}/.local/share/applications

--- a/phoenicis-configuration/src/main/resources/Mac OS X.properties
+++ b/phoenicis-configuration/src/main/resources/Mac OS X.properties
@@ -21,6 +21,7 @@ application.version                         =           ${project.version}
 application.gitRevision                     =           ${buildNumber}
 application.buildTimestamp                  =           ${timestamp}
 application.theme                           =           default
+application.viewsource                      =           false
 
 application.user.root                       =           ${user.home}/Library/Phoenicis
 application.user.desktopShortcuts           =           ${application.user.root}/desktopShortcuts


### PR DESCRIPTION
Added the missing default value for the new `viewsource` property.
See the comments on commit 4b08e122ae034459e614939d398a2f4a6a774387 for details.