### PR TITLE
Set the javafx configuration test as ignored

### DIFF
--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/AppConfigurationInitialisationTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/AppConfigurationInitialisationTest.java
@@ -5,6 +5,7 @@ package org.phoenicis.javafx;
 
 import java.util.concurrent.TimeoutException;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.testfx.api.FxToolkit;
@@ -16,6 +17,7 @@ import org.testfx.api.FxToolkit;
 public class AppConfigurationInitialisationTest {
 
 	@Test
+	@Ignore
 	public void testAppConfigurationInitialisation() throws TimeoutException {
 		FxToolkit.registerPrimaryStage();
 		FxToolkit.setupFixture(() -> new AnnotationConfigApplicationContext(AppConfiguration.class));


### PR DESCRIPTION
This PR should temporarily solve #673 by ignoring the configuration test. This test should be included again at the time when the textfx team releases their next version 4.0.6-alpha.

It would be nice if someone with the problem described in #673 could test this PR.