### PR TITLE
Reinsert the configuration initialisation test

### DIFF
--- a/phoenicis-javafx/pom.xml
+++ b/phoenicis-javafx/pom.xml
@@ -125,7 +125,7 @@
 		<dependency>
 			<groupId>org.testfx</groupId>
 			<artifactId>testfx-junit</artifactId>
-			<version>4.0.5-alpha</version>
+			<version>4.0.6-alpha</version>
 			<scope>test</scope>
 		</dependency>
 		

--- a/phoenicis-javafx/pom.xml
+++ b/phoenicis-javafx/pom.xml
@@ -28,6 +28,10 @@
 
     <artifactId>phoenicis-javafx</artifactId>
 
+    <properties>
+        <testfx.version>4.0.6-alpha</testfx.version>
+    </properties>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -118,14 +122,14 @@
         <dependency>
 			<groupId>org.testfx</groupId>
 			<artifactId>testfx-core</artifactId>
-			<version>4.0.5-alpha</version>
+			<version>${testfx.version}</version>
 			<scope>test</scope>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.testfx</groupId>
 			<artifactId>testfx-junit</artifactId>
-			<version>4.0.6-alpha</version>
+			<version>${testfx.version}</version>
 			<scope>test</scope>
 		</dependency>
 		

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/AppConfigurationInitialisationTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/AppConfigurationInitialisationTest.java
@@ -3,12 +3,11 @@
  */
 package org.phoenicis.javafx;
 
-import java.util.concurrent.TimeoutException;
-
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.testfx.api.FxToolkit;
+
+import java.util.concurrent.TimeoutException;
 
 /**
  * @author marc

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/AppConfigurationInitialisationTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/AppConfigurationInitialisationTest.java
@@ -17,7 +17,6 @@ import org.testfx.api.FxToolkit;
 public class AppConfigurationInitialisationTest {
 
 	@Test
-	@Ignore
 	public void testAppConfigurationInitialisation() throws TimeoutException {
 		FxToolkit.registerPrimaryStage();
 		FxToolkit.setupFixture(() -> new AnnotationConfigApplicationContext(AppConfiguration.class));


### PR DESCRIPTION
This PR updates testfx to version `4.0.6-alpha` and reinserts the configuration initialisation test. This should fix #673.