### PR TITLE
Add repository manager

### DIFF
--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/AppsConfiguration.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/AppsConfiguration.java
@@ -28,8 +28,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
-import java.io.File;
-
 @Configuration
 public class AppsConfiguration {
     @Value("${application.repository.configuration}")
@@ -51,25 +49,36 @@ public class AppsConfiguration {
     private FileUtilities fileUtilities;
 
     @Bean
-    public Repository repository() {
-        Repository repository = new ConfigurableRepository(
-                repositoryConfiguration,
-                cacheDirectoryPath,
-                fileUtilities,
-                new LocalRepository.Factory(objectMapper()),
-                new ClasspathRepository.Factory(objectMapper(), new PathMatchingResourcePatternResolver())
-        );
-        return new FilterRepository(
-                new CachedRepository(repository),
-                toolsConfiguration.operatingSystemFetcher(),
-                enforceUncompatibleOperatingSystems
-        );
+    public RepositoryManager repositoryManager() {
+        RepositoryManager repositoryManager = new RepositoryManager(multithreadingConfiguration.appsExecutorService(), enforceUncompatibleOperatingSystems, toolsConfiguration, cacheDirectoryPath, fileUtilities,
+                new LocalRepository.Factory(objectMapper()), new ClasspathRepository.Factory(objectMapper(), new PathMatchingResourcePatternResolver()));
+
+        // set initial repositories
+        repositoryManager.addRepositories(this.repositoryConfiguration.split(";"));
+
+        return repositoryManager;
     }
 
-    @Bean
-    public Repository backgroundRepository() {
-        return new BackgroundRepository(repository(), multithreadingConfiguration.appsExecutorService());
-    }
+//    @Bean
+//    public Repository repository() {
+//        Repository repository = new ConfigurableRepository(
+//                repositoryConfiguration,
+//                cacheDirectoryPath,
+//                fileUtilities,
+//                new LocalRepository.Factory(objectMapper()),
+//                new ClasspathRepository.Factory(objectMapper(), new PathMatchingResourcePatternResolver())
+//        );
+//        return new FilterRepository(
+//                new CachedRepository(repository),
+//                toolsConfiguration.operatingSystemFetcher(),
+//                enforceUncompatibleOperatingSystems
+//        );
+//    }
+//
+//    @Bean
+//    public Repository backgroundRepository() {
+//        return new BackgroundRepository(repository(), multithreadingConfiguration.appsExecutorService());
+//    }
 
     @Bean
     ObjectMapper objectMapper() {

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/BackgroundRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/BackgroundRepository.java
@@ -18,6 +18,8 @@
 
 package org.phoenicis.apps;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.apps.dto.CategoryDTO;
 import org.phoenicis.apps.dto.ScriptDTO;
 
@@ -62,16 +64,29 @@ class BackgroundRepository implements Repository {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         BackgroundRepository that = (BackgroundRepository) o;
 
-        return delegatedRepository != null ? delegatedRepository.equals(that.delegatedRepository) : that.delegatedRepository == null;
+        EqualsBuilder builder = new EqualsBuilder();
+
+        builder.append(delegatedRepository, that.delegatedRepository);
+
+        return builder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        return delegatedRepository != null ? delegatedRepository.hashCode() : 0;
+        HashCodeBuilder builder = new HashCodeBuilder();
+
+        builder.append(delegatedRepository);
+
+        return builder.toHashCode();
     }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/BackgroundRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/BackgroundRepository.java
@@ -59,4 +59,19 @@ class BackgroundRepository implements Repository {
     public void setFilter(CombinedAppsFilter filter) {
         delegatedRepository.setFilter(filter);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BackgroundRepository that = (BackgroundRepository) o;
+
+        return delegatedRepository != null ? delegatedRepository.equals(that.delegatedRepository) : that.delegatedRepository == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return delegatedRepository != null ? delegatedRepository.hashCode() : 0;
+    }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/CachedRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/CachedRepository.java
@@ -18,6 +18,9 @@
 
 package org.phoenicis.apps;
 
+import com.jcraft.jsch.HASH;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.apps.dto.CategoryDTO;
 
 import java.util.List;
@@ -50,16 +53,29 @@ class CachedRepository implements Repository {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         CachedRepository that = (CachedRepository) o;
 
-        return repository != null ? repository.equals(that.repository) : that.repository == null;
+        EqualsBuilder builder = new EqualsBuilder();
+
+        builder.append(repository, that.repository);
+
+        return builder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        return repository != null ? repository.hashCode() : 0;
+        HashCodeBuilder builder = new HashCodeBuilder();
+
+        builder.append(repository);
+
+        return builder.toHashCode();
     }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/CachedRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/CachedRepository.java
@@ -47,4 +47,19 @@ class CachedRepository implements Repository {
     public void clearCache() {
         this.cache = null;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CachedRepository that = (CachedRepository) o;
+
+        return repository != null ? repository.equals(that.repository) : that.repository == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return repository != null ? repository.hashCode() : 0;
+    }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/CachedRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/CachedRepository.java
@@ -43,4 +43,8 @@ class CachedRepository implements Repository {
     public void onDelete() {
         this.repository.onDelete();
     }
+
+    public void clearCache() {
+        this.cache = null;
+    }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/ClasspathRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/ClasspathRepository.java
@@ -151,6 +151,21 @@ class ClasspathRepository implements Repository {
                 .build();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ClasspathRepository that = (ClasspathRepository) o;
+
+        return packagePath != null ? packagePath.equals(that.packagePath) : that.packagePath == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return packagePath != null ? packagePath.hashCode() : 0;
+    }
+
     static class Factory {
         private final ObjectMapper objectMapper;
         private final ResourcePatternResolver resourceResolver;

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/ClasspathRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/ClasspathRepository.java
@@ -19,6 +19,8 @@
 package org.phoenicis.apps;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.apps.dto.ApplicationDTO;
 import org.phoenicis.apps.dto.CategoryDTO;
 import org.phoenicis.apps.dto.ScriptDTO;
@@ -153,17 +155,30 @@ class ClasspathRepository implements Repository {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         ClasspathRepository that = (ClasspathRepository) o;
 
-        return packagePath != null ? packagePath.equals(that.packagePath) : that.packagePath == null;
+        EqualsBuilder builder = new EqualsBuilder();
+
+        builder.append(packagePath, that.packagePath);
+
+        return builder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        return packagePath != null ? packagePath.hashCode() : 0;
+        HashCodeBuilder builder = new HashCodeBuilder();
+
+        builder.append(packagePath);
+
+        return builder.toHashCode();
     }
 
     static class Factory {

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/ConfigurableRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/ConfigurableRepository.java
@@ -18,6 +18,8 @@
 
 package org.phoenicis.apps;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.apps.dto.CategoryDTO;
 import org.phoenicis.tools.files.FileUtilities;
 import org.slf4j.Logger;
@@ -84,19 +86,31 @@ class ConfigurableRepository implements Repository {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         ConfigurableRepository that = (ConfigurableRepository) o;
 
-        if (repository != null ? !repository.equals(that.repository) : that.repository != null) return false;
-        return cacheDirectoryPath != null ? cacheDirectoryPath.equals(that.cacheDirectoryPath) : that.cacheDirectoryPath == null;
+        EqualsBuilder builder = new EqualsBuilder();
+
+        builder.append(repository, that.repository);
+        builder.append(cacheDirectoryPath, that.cacheDirectoryPath);
+
+        return builder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result = repository != null ? repository.hashCode() : 0;
-        result = 31 * result + (cacheDirectoryPath != null ? cacheDirectoryPath.hashCode() : 0);
-        return result;
+        HashCodeBuilder builder = new HashCodeBuilder();
+
+        builder.append(repository);
+        builder.append(cacheDirectoryPath);
+
+        return builder.toHashCode();
     }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/ConfigurableRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/ConfigurableRepository.java
@@ -81,4 +81,22 @@ class ConfigurableRepository implements Repository {
             return new NullRepository();
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ConfigurableRepository that = (ConfigurableRepository) o;
+
+        if (repository != null ? !repository.equals(that.repository) : that.repository != null) return false;
+        return cacheDirectoryPath != null ? cacheDirectoryPath.equals(that.cacheDirectoryPath) : that.cacheDirectoryPath == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = repository != null ? repository.hashCode() : 0;
+        result = 31 * result + (cacheDirectoryPath != null ? cacheDirectoryPath.hashCode() : 0);
+        return result;
+    }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/FilterRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/FilterRepository.java
@@ -18,6 +18,8 @@
 
 package org.phoenicis.apps;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.entities.OperatingSystem;
 import org.phoenicis.apps.dto.ApplicationDTO;
 import org.phoenicis.apps.dto.CategoryDTO;
@@ -93,24 +95,35 @@ class FilterRepository implements Repository {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         FilterRepository that = (FilterRepository) o;
 
-        if (enforceIncompatibleOperatingSystems != that.enforceIncompatibleOperatingSystems) return false;
-        if (repository != null ? !repository.equals(that.repository) : that.repository != null) return false;
-        if (operatingSystemFetcher != null ? !operatingSystemFetcher.equals(that.operatingSystemFetcher) : that.operatingSystemFetcher != null)
-            return false;
-        return filter != null ? filter.equals(that.filter) : that.filter == null;
+        EqualsBuilder builder = new EqualsBuilder();
+
+        builder.append(enforceIncompatibleOperatingSystems, that.enforceIncompatibleOperatingSystems);
+        builder.append(repository, that.repository);
+        builder.append(operatingSystemFetcher, that.operatingSystemFetcher);
+        builder.append(filter, that.filter);
+
+        return builder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result = repository != null ? repository.hashCode() : 0;
-        result = 31 * result + (operatingSystemFetcher != null ? operatingSystemFetcher.hashCode() : 0);
-        result = 31 * result + (enforceIncompatibleOperatingSystems ? 1 : 0);
-        result = 31 * result + (filter != null ? filter.hashCode() : 0);
-        return result;
+        HashCodeBuilder builder = new HashCodeBuilder();
+
+        builder.append(enforceIncompatibleOperatingSystems);
+        builder.append(repository);
+        builder.append(enforceIncompatibleOperatingSystems);
+        builder.append(filter);
+
+        return builder.toHashCode();
     }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/FilterRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/FilterRepository.java
@@ -90,4 +90,27 @@ class FilterRepository implements Repository {
     public void setFilter(CombinedAppsFilter filter) {
         this.filter = filter;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FilterRepository that = (FilterRepository) o;
+
+        if (enforceIncompatibleOperatingSystems != that.enforceIncompatibleOperatingSystems) return false;
+        if (repository != null ? !repository.equals(that.repository) : that.repository != null) return false;
+        if (operatingSystemFetcher != null ? !operatingSystemFetcher.equals(that.operatingSystemFetcher) : that.operatingSystemFetcher != null)
+            return false;
+        return filter != null ? filter.equals(that.filter) : that.filter == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = repository != null ? repository.hashCode() : 0;
+        result = 31 * result + (operatingSystemFetcher != null ? operatingSystemFetcher.hashCode() : 0);
+        result = 31 * result + (enforceIncompatibleOperatingSystems ? 1 : 0);
+        result = 31 * result + (filter != null ? filter.hashCode() : 0);
+        return result;
+    }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/GitRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/GitRepository.java
@@ -18,6 +18,8 @@
 
 package org.phoenicis.apps;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
@@ -129,16 +131,31 @@ class GitRepository implements Repository {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 
 		GitRepository that = (GitRepository) o;
 
-		return gitRepositoryURL != null ? gitRepositoryURL.equals(that.gitRepositoryURL) : that.gitRepositoryURL == null;
+		EqualsBuilder builder = new EqualsBuilder();
+
+		builder.append(gitRepositoryURL, that.gitRepositoryURL);
+		builder.append(gitRepositoryLocation, that.gitRepositoryLocation);
+
+		return builder.isEquals();
 	}
 
 	@Override
 	public int hashCode() {
-		return gitRepositoryURL != null ? gitRepositoryURL.hashCode() : 0;
+		HashCodeBuilder builder = new HashCodeBuilder();
+
+		builder.append(gitRepositoryURL);
+		builder.append(gitRepositoryLocation);
+
+		return builder.toHashCode();
 	}
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/GitRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/GitRepository.java
@@ -126,4 +126,19 @@ class GitRepository implements Repository {
 			LOGGER.error(String.format("Couldn't delete local git-repository at: '%s'", gitRepositoryLocation.getAbsolutePath()), e);
 		}
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		GitRepository that = (GitRepository) o;
+
+		return gitRepositoryURL != null ? gitRepositoryURL.equals(that.gitRepositoryURL) : that.gitRepositoryURL == null;
+	}
+
+	@Override
+	public int hashCode() {
+		return gitRepositoryURL != null ? gitRepositoryURL.hashCode() : 0;
+	}
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/LocalRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/LocalRepository.java
@@ -239,6 +239,21 @@ class LocalRepository implements Repository {
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        LocalRepository that = (LocalRepository) o;
+
+        return repositoryDirectory != null ? repositoryDirectory.equals(that.repositoryDirectory) : that.repositoryDirectory == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return repositoryDirectory != null ? repositoryDirectory.hashCode() : 0;
+    }
+
     static class Factory {
         private final ObjectMapper objectMapper;
 

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/LocalRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/LocalRepository.java
@@ -19,6 +19,8 @@
 package org.phoenicis.apps;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.apps.dto.ApplicationDTO;
 import org.phoenicis.apps.dto.CategoryDTO;
 import org.phoenicis.apps.dto.ResourceDTO;
@@ -241,17 +243,30 @@ class LocalRepository implements Repository {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         LocalRepository that = (LocalRepository) o;
 
-        return repositoryDirectory != null ? repositoryDirectory.equals(that.repositoryDirectory) : that.repositoryDirectory == null;
+        EqualsBuilder builder = new EqualsBuilder();
+
+        builder.append(repositoryDirectory, that.repositoryDirectory);
+
+        return builder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        return repositoryDirectory != null ? repositoryDirectory.hashCode() : 0;
+        HashCodeBuilder builder = new HashCodeBuilder();
+
+        builder.append(repositoryDirectory);
+
+        return builder.toHashCode();
     }
 
     static class Factory {

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/MultipleRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/MultipleRepository.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.apps.dto.CategoryDTO;
 
 class MultipleRepository extends MergeableRepository {
@@ -91,17 +93,29 @@ class MultipleRepository extends MergeableRepository {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 
 		MultipleRepository that = (MultipleRepository) o;
 
-		// Probably incorrect - comparing Object[] arrays with Arrays.equals
-		return Arrays.equals(repositories, that.repositories);
+		EqualsBuilder builder = new EqualsBuilder();
+
+		builder.append(repositories, that.repositories);
+
+		return builder.isEquals();
 	}
 
 	@Override
 	public int hashCode() {
-		return Arrays.hashCode(repositories);
+		HashCodeBuilder builder = new HashCodeBuilder();
+
+		builder.append(repositories);
+
+		return builder.toHashCode();
 	}
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/MultipleRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/MultipleRepository.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import org.phoenicis.apps.dto.CategoryDTO;
 
 class MultipleRepository extends MergeableRepository {
-	private final Repository[] repositories;
+	private Repository[] repositories;
 
 	MultipleRepository(Repository... repositories) {
 		this.repositories = repositories;
@@ -53,5 +53,21 @@ class MultipleRepository extends MergeableRepository {
 	@Override
 	public void onDelete() {
 		Arrays.stream(repositories).forEach(Repository::onDelete);
+	}
+
+	public void addRepository(Repository repository) {
+		Repository[] newRepositories = Arrays.copyOf(this.repositories, this.repositories.length + 1);
+
+		newRepositories[this.repositories.length] = repository;
+
+		this.repositories = newRepositories;
+	}
+
+	public void removeRepository(Repository repository) {
+		List<Repository> newRepositories = Arrays.asList(this.repositories);
+
+		newRepositories.remove(repository);
+
+		this.repositories = newRepositories.toArray(new Repository[0]);
 	}
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/MultipleRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/MultipleRepository.java
@@ -19,6 +19,7 @@
 package org.phoenicis.apps;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -55,6 +56,18 @@ class MultipleRepository extends MergeableRepository {
 		Arrays.stream(repositories).forEach(Repository::onDelete);
 	}
 
+	public void moveRepository(Repository repository, int toIndex) {
+		List<Repository> newRepositories = Arrays.asList(this.repositories);
+
+		int oldIndex = newRepositories.indexOf(repository);
+
+		if (oldIndex >= 0 && toIndex >= 0 && toIndex < newRepositories.size()) {
+			Collections.swap(newRepositories, oldIndex, toIndex);
+
+			this.repositories = newRepositories.toArray(new Repository[0]);
+		}
+	}
+
 	public void addRepository(Repository repository) {
 		Repository[] newRepositories = Arrays.copyOf(this.repositories, this.repositories.length + 1);
 
@@ -64,10 +77,29 @@ class MultipleRepository extends MergeableRepository {
 	}
 
 	public void removeRepository(Repository repository) {
-		List<Repository> newRepositories = Arrays.asList(this.repositories);
+		int index = Arrays.asList(this.repositories).indexOf(repository);
 
-		newRepositories.remove(repository);
+		if (index >= 0) {
+			Repository[] newRepositories = new Repository[this.repositories.length - 1];
 
-		this.repositories = newRepositories.toArray(new Repository[0]);
+			System.arraycopy(this.repositories, 0, newRepositories, 0, index);
+			System.arraycopy(this.repositories, index + 1, newRepositories, index, this.repositories.length - 1 - index);
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		MultipleRepository that = (MultipleRepository) o;
+
+		// Probably incorrect - comparing Object[] arrays with Arrays.equals
+		return Arrays.equals(repositories, that.repositories);
+	}
+
+	@Override
+	public int hashCode() {
+		return Arrays.hashCode(repositories);
 	}
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/MultipleRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/MultipleRepository.java
@@ -84,6 +84,8 @@ class MultipleRepository extends MergeableRepository {
 
 			System.arraycopy(this.repositories, 0, newRepositories, 0, index);
 			System.arraycopy(this.repositories, index + 1, newRepositories, index, this.repositories.length - 1 - index);
+
+			this.repositories = newRepositories;
 		}
 	}
 

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/RepositoryManager.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/RepositoryManager.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * Created by marc on 31.03.17.
@@ -86,8 +87,13 @@ public class RepositoryManager {
 
     public void removeRepositories(String ... repositoryUrls) {
         LOGGER.info(String.format("Removing repositories: %s", Arrays.toString(repositoryUrls)));
-        Arrays.stream(repositoryUrls).map(this::toRepository).forEach(this.multipleRepository::removeRepository);
+
+        List<Repository> toDeleteRepositories = Arrays.stream(repositoryUrls).map(this::toRepository).collect(Collectors.toList());
+        toDeleteRepositories.forEach(this.multipleRepository::removeRepository);
+
         this.triggerRepositoryChange();
+
+        toDeleteRepositories.forEach(Repository::onDelete);
     }
 
     public void removeRepository(String repositoryUrl) {
@@ -107,7 +113,7 @@ public class RepositoryManager {
     }
 
     private Repository toRepository(String repositoryUrl) {
-        LOGGER.info("Registering: " + repositoryUrl);
+        LOGGER.info("Converting: " + repositoryUrl + " to Repository");
         try {
             final URI url = new URI(repositoryUrl);
             final String scheme = url.getScheme().split("\\+")[0];

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/RepositoryManager.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/RepositoryManager.java
@@ -66,17 +66,32 @@ public class RepositoryManager {
         this.triggerRepositoryChange();
     }
 
+    public void moveRepository(String repositoryUrl, int toIndex) {
+        LOGGER.info(String.format("Move repository: %s to %d", repositoryUrl, toIndex));
+        this.multipleRepository.moveRepository(toRepository(repositoryUrl), toIndex);
+        this.triggerRepositoryChange();
+    }
+
     public void addRepositories(String ... repositoryUrls) {
+        LOGGER.info(String.format("Adding repositories: %s", Arrays.toString(repositoryUrls)));
         Arrays.stream(repositoryUrls).map(this::toRepository).forEach(this.multipleRepository::addRepository);
         this.triggerRepositoryChange();
     }
 
     public void addRepository(String repositoryUrl) {
+        LOGGER.info(String.format("Adding repository: %s", repositoryUrl));
         this.multipleRepository.addRepository(toRepository(repositoryUrl));
         this.triggerRepositoryChange();
     }
 
+    public void removeRepositories(String ... repositoryUrls) {
+        LOGGER.info(String.format("Removing repositories: %s", Arrays.toString(repositoryUrls)));
+        Arrays.stream(repositoryUrls).map(this::toRepository).forEach(this.multipleRepository::removeRepository);
+        this.triggerRepositoryChange();
+    }
+
     public void removeRepository(String repositoryUrl) {
+        LOGGER.info(String.format("Removing repository: %s", repositoryUrl));
         Repository toDelete = toRepository(repositoryUrl);
         this.multipleRepository.removeRepository(toDelete);
         this.triggerRepositoryChange();

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/RepositoryManager.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/RepositoryManager.java
@@ -1,0 +1,117 @@
+package org.phoenicis.apps;
+
+import org.phoenicis.apps.dto.CategoryDTO;
+import org.phoenicis.multithreading.ControlledThreadPoolExecutorService;
+import org.phoenicis.tools.ToolsConfiguration;
+import org.phoenicis.tools.files.FileUtilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+
+/**
+ * Created by marc on 31.03.17.
+ */
+public class RepositoryManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryManager.class);
+
+    private final LocalRepository.Factory localRepositoryFactory;
+    private final ClasspathRepository.Factory classPathRepositoryFactory;
+    private final String cacheDirectoryPath;
+
+    private final FileUtilities fileUtilities;
+
+    private MultipleRepository multipleRepository;
+    private FilterRepository filterRepository;
+    private CachedRepository cachedRepository;
+    private BackgroundRepository backgroundRepository;
+
+    private Consumer<List<CategoryDTO>> onRepositoryChange;
+    private Consumer<Exception> onError;
+
+    public RepositoryManager(ExecutorService executorService, boolean enforceUncompatibleOperatingSystems, ToolsConfiguration toolsConfiguration, String cacheDirectoryPath, FileUtilities fileUtilities, LocalRepository.Factory localRepositoryFactory, ClasspathRepository.Factory classPathRepositoryFactory) {
+        super();
+
+        this.localRepositoryFactory = localRepositoryFactory;
+        this.classPathRepositoryFactory = classPathRepositoryFactory;
+        this.cacheDirectoryPath = cacheDirectoryPath;
+        this.fileUtilities = fileUtilities;
+
+        this.multipleRepository = new MultipleRepository();
+        this.filterRepository = new FilterRepository(multipleRepository, toolsConfiguration.operatingSystemFetcher(), enforceUncompatibleOperatingSystems);
+        this.cachedRepository = new CachedRepository(filterRepository);
+        this.backgroundRepository = new BackgroundRepository(cachedRepository, executorService);
+    }
+
+    public void setOnRepositoryChange(Consumer<List<CategoryDTO>> onRepositoryChange) {
+        this.onRepositoryChange = onRepositoryChange;
+    }
+
+    public void setOnError(Consumer<Exception> onError) {
+        this.onError = onError;
+    }
+
+    public Repository cachedRepository() {
+        return this.cachedRepository;
+    }
+
+    @Deprecated
+    public void setFilter(CombinedAppsFilter filter) {
+        this.filterRepository.setFilter(filter);
+        this.triggerRepositoryChange();
+    }
+
+    public void addRepositories(String ... repositoryUrls) {
+        Arrays.stream(repositoryUrls).map(this::toRepository).forEach(this.multipleRepository::addRepository);
+        this.triggerRepositoryChange();
+    }
+
+    public void addRepository(String repositoryUrl) {
+        this.multipleRepository.addRepository(toRepository(repositoryUrl));
+        this.triggerRepositoryChange();
+    }
+
+    public void removeRepository(String repositoryUrl) {
+        Repository toDelete = toRepository(repositoryUrl);
+        this.multipleRepository.removeRepository(toDelete);
+        this.triggerRepositoryChange();
+        toDelete.onDelete();
+    }
+
+    public void triggerRepositoryChange() {
+        this.cachedRepository.clearCache();
+
+        if (this.onRepositoryChange != null && this.onError != null) {
+            this.backgroundRepository.fetchInstallableApplications(onRepositoryChange, onError);
+        }
+    }
+
+    private Repository toRepository(String repositoryUrl) {
+        LOGGER.info("Registering: " + repositoryUrl);
+        try {
+            final URI url = new URI(repositoryUrl);
+            final String scheme = url.getScheme().split("\\+")[0];
+
+            switch (scheme) {
+                case "git":
+                    return new GitRepository(repositoryUrl.replace("git+",""), cacheDirectoryPath,
+                            localRepositoryFactory, fileUtilities);
+                case "file":
+                    return localRepositoryFactory.createInstance(url.getRawPath());
+                case "classpath":
+                    return classPathRepositoryFactory.createInstance(url.getPath());
+                default:
+                    LOGGER.warn("Unsupported URL: " + repositoryUrl);
+                    return new NullRepository();
+            }
+        } catch (URISyntaxException e) {
+            LOGGER.warn("Cannot parse URL: " + repositoryUrl, e);
+            return new NullRepository();
+        }
+    }
+}

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/TeeRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/TeeRepository.java
@@ -55,4 +55,23 @@ public class TeeRepository extends MergeableRepository {
         this.leftRepository.onDelete();
         this.rightRepository.onDelete();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TeeRepository that = (TeeRepository) o;
+
+        if (leftRepository != null ? !leftRepository.equals(that.leftRepository) : that.leftRepository != null)
+            return false;
+        return rightRepository != null ? rightRepository.equals(that.rightRepository) : that.rightRepository == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = leftRepository != null ? leftRepository.hashCode() : 0;
+        result = 31 * result + (rightRepository != null ? rightRepository.hashCode() : 0);
+        return result;
+    }
 }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/TeeRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/TeeRepository.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.apps.dto.CategoryDTO;
 
 public class TeeRepository extends MergeableRepository {
@@ -58,20 +60,31 @@ public class TeeRepository extends MergeableRepository {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         TeeRepository that = (TeeRepository) o;
 
-        if (leftRepository != null ? !leftRepository.equals(that.leftRepository) : that.leftRepository != null)
-            return false;
-        return rightRepository != null ? rightRepository.equals(that.rightRepository) : that.rightRepository == null;
+        EqualsBuilder builder = new EqualsBuilder();
+
+        builder.append(leftRepository, that.leftRepository);
+        builder.append(rightRepository, that.rightRepository);
+
+        return builder.isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result = leftRepository != null ? leftRepository.hashCode() : 0;
-        result = 31 * result + (rightRepository != null ? rightRepository.hashCode() : 0);
-        return result;
+        HashCodeBuilder builder = new HashCodeBuilder();
+
+        builder.append(leftRepository);
+        builder.append(rightRepository);
+
+        return builder.toHashCode();
     }
 }

--- a/phoenicis-javafx/pom.xml
+++ b/phoenicis-javafx/pom.xml
@@ -115,12 +115,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.fxmisc.easybind</groupId>
-            <artifactId>easybind</artifactId>
-            <version>1.0.3</version>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
@@ -120,7 +120,7 @@ public class ControllerConfiguration {
     public AppsController appsController() {
         return new AppsController(
                 viewsConfiguration.viewApps(),
-                appsConfiguration.backgroundRepository(),
+                appsConfiguration.repositoryManager(),
                 scriptsConfiguration.scriptInterpreter(),
                 settingsConfiguration.settingsManager()
         );

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
@@ -20,6 +20,7 @@ package org.phoenicis.javafx.controller.apps;
 
 import javafx.application.Platform;
 import org.phoenicis.apps.Repository;
+import org.phoenicis.apps.RepositoryManager;
 import org.phoenicis.apps.dto.ApplicationDTO;
 import org.phoenicis.apps.dto.CategoryDTO;
 import org.phoenicis.javafx.views.common.ErrorMessage;
@@ -34,43 +35,34 @@ import java.util.List;
 
 public class AppsController {
     private final ViewApps view;
-    private final Repository repository;
+    private final RepositoryManager repositoryManager;
     private final ScriptInterpreter scriptInterpreter;
     private final SettingsManager settingsManager;
     
     private Runnable onAppLoaded = () -> {};
 
     public AppsController(ViewApps view,
-                          Repository repository,
+                          RepositoryManager repositoryManager,
                           ScriptInterpreter scriptInterpreter,
                           SettingsManager settingsManager) {
         this.view = view;
-        this.repository = repository;
+        this.repositoryManager = repositoryManager;
         this.scriptInterpreter = scriptInterpreter;
         this.settingsManager = settingsManager;
-        
-        this.view.setOnApplyFilter(filter -> {
-            repository.setFilter(filter);
-            repository.fetchInstallableApplications(
-                    this.view::populate,
-                    e -> this.view.showFailure()
-            );
-        });
+
+        this.repositoryManager.setOnRepositoryChange(this.view::populate);
+        this.repositoryManager.setOnError(e -> this.view.showFailure());
+
+        this.view.setOnApplyFilter(repositoryManager::setFilter);
     }
 
     public void loadApps() {
         this.view.showWait();
-        repository.fetchInstallableApplications(
-                this.view::populate,
-                e -> this.view.showFailure()
-        );
+        this.repositoryManager.triggerRepositoryChange();
 
         this.view.setOnRetryButtonClicked(event -> {
             this.view.showWait();
-            repository.fetchInstallableApplications(
-                    this.view::populate,
-                    e -> this.view.showFailure()
-            );
+            this.repositoryManager.triggerRepositoryChange();
         });
 
         this.view.setOnSelectAll(categories -> {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/ViewsConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/ViewsConfiguration.java
@@ -18,6 +18,7 @@
 
 package org.phoenicis.javafx.views;
 
+import org.phoenicis.apps.AppsConfiguration;
 import org.phoenicis.containers.dto.WinePrefixContainerDTO;
 import org.phoenicis.javafx.views.common.ThemeConfiguration;
 import org.phoenicis.javafx.views.common.widget.PhoenicisLogo;
@@ -65,6 +66,9 @@ public class ViewsConfiguration {
     @Autowired
     private SettingsConfiguration settingsConfiguration;
 
+    @Autowired
+    private AppsConfiguration appsConfiguration;
+
     @Bean
     public ViewApps viewApps() {
         return new ViewApps(themeConfiguration.themeManager(), settingsConfiguration.settingsManager());
@@ -82,7 +86,7 @@ public class ViewsConfiguration {
 
     @Bean
     public ViewSettings viewSettings() {
-        return new ViewSettings(themeConfiguration.themeManager(), applicationName, applicationVersion, applicationGitRevision, applicationBuildTimestamp, toolsConfiguration.opener(), settingsConfiguration.settingsManager());
+        return new ViewSettings(themeConfiguration.themeManager(), applicationName, applicationVersion, applicationGitRevision, applicationBuildTimestamp, toolsConfiguration.opener(), settingsConfiguration.settingsManager(), appsConfiguration.repositoryManager());
     }
 
     @Bean

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/ExpandedList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/ExpandedList.java
@@ -1,0 +1,209 @@
+package org.phoenicis.javafx.views.common;
+
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.TransformationList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Created by marc on 01.04.17.
+ */
+public class ExpandedList<E, F> extends TransformationList<E, F> {
+    private final Function<? super F, List<? extends E>> expander;
+
+    private List<Integer> sourceMapping;
+    private List<E> expandedValues;
+
+    public ExpandedList(ObservableList<? extends F> source, Function<? super F, List<? extends E>> expander) {
+        super(source);
+
+        this.expander = expander;
+        this.sourceMapping = new ArrayList<Integer>();
+        this.expandedValues = new ArrayList<E>();
+
+        for (int index = 0; index < source.size(); index++) {
+            List<? extends E> expanded = expander.apply(source.get(index));
+
+            this.sourceMapping.add(expanded.size());
+            this.expandedValues.addAll(expanded);
+        }
+    }
+
+    @Override
+    public int getSourceIndex(int index) {
+        if (index >= size()) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        int sum = 0;
+        int sourceIndex = -1;
+
+        for (int i = 0; i < getSource().size(); i++) {
+            if (index < sum) {
+                break;
+            }
+
+            sum += sourceMapping.get(i);
+            sourceIndex++;
+        }
+
+        return sourceIndex;
+    }
+
+    @Override
+    public E get(int index) {
+        if (index >= size()) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        return expandedValues.get(index);
+    }
+
+    @Override
+    public int size() {
+        return expandedValues.size();
+    }
+
+    private int getFirstPosition(int sourceIndex) {
+        int position = 0;
+
+        for (int i = 0; i < sourceIndex; i++) {
+            position += sourceMapping.get(i);
+        }
+
+        return position;
+    }
+
+    private int getLastPosition(int sourceIndex) {
+        int position = 0;
+
+        for (int i = 0; i <= sourceIndex; i++) {
+            position += sourceMapping.get(i);
+        }
+
+        return position;
+    }
+
+    private void permutate(ListChangeListener.Change<? extends F> c) {
+        int from = c.getFrom();
+        int to = c.getTo();
+
+        if (to > from) {
+            List<E> valuesClone = new ArrayList<E>(expandedValues);
+            List<Integer> positionClone = new ArrayList<Integer>(sourceMapping);
+
+            for (int i = from; i < to; ++i) {
+                int firstOldIndex = getFirstPosition(i);
+                int lastOldIndexPlusOne = getLastPosition(i);
+
+                int firstNewIndex = getFirstPosition(c.getPermutation(i));
+
+                List<E> permutatedValues = new ArrayList<E>(valuesClone.subList(firstOldIndex, lastOldIndexPlusOne));
+
+                expandedValues.removeAll(permutatedValues);
+
+                if (firstNewIndex >= lastOldIndexPlusOne) {
+                    expandedValues.addAll(firstNewIndex - (lastOldIndexPlusOne - 1 - firstOldIndex), permutatedValues);
+                } else {
+                    expandedValues.addAll(firstNewIndex, permutatedValues);
+                }
+
+                Collections.swap(positionClone, i, c.getPermutation(i));
+            }
+
+            this.sourceMapping = positionClone;
+
+            int[] perm = sourceMapping.stream().flatMap(value -> IntStream.range(0, value).boxed()).mapToInt(i -> i).toArray();
+
+            nextPermutation(from, to, perm);
+        }
+    }
+
+    private void update(ListChangeListener.Change<? extends F> c) {
+        int from = c.getFrom();
+        int to = c.getTo();
+
+        if (to > from) {
+            for (int i = from; i < to; ++i) {
+                int firstOldIndex = getFirstPosition(i);
+                int lastOldIndexPlusOne = getLastPosition(i);
+
+                // delete old values
+                removeSourceValue(i, firstOldIndex, lastOldIndexPlusOne);
+
+                // add new values
+                addSourceValue(i, firstOldIndex);
+            }
+        }
+    }
+
+    /**
+     * Processes the removal of an element in the source list.
+     * This leads to the removal of all elements that were expanded from the source element in this list
+     * @param index             The index of the removed element in the source list
+     * @param firstIndex     The occurance of the first element, that was expanded from the to be deleted source element in this list
+     * @param lastIndexPlusOne      The occurance of the last element, that was expanded from the to be deleted source element in this list
+     */
+    private void removeSourceValue(int index, int firstIndex, int lastIndexPlusOne) {
+        for (int innerIndex = lastIndexPlusOne - 1; innerIndex >= firstIndex; innerIndex--) {
+            nextRemove(innerIndex, expandedValues.remove(innerIndex));
+        }
+
+        sourceMapping.remove(index);
+    }
+
+    /**
+     * Processes the addition of a new element in the source list.
+     * This leads to the addition of all elements that can be expanded from the source element in this list at the given @param firstIndex
+     * @param index             The index of the added element in the source list
+     * @param firstIndex     The starting index of the first element, that was expanded from the new source value in this list
+     */
+    private void addSourceValue(int index, int firstIndex) {
+        List<? extends E> newValues = expander.apply(getSource().get(index));
+
+        sourceMapping.add(index, newValues.size());
+        expandedValues.addAll(firstIndex, newValues);
+
+        nextAdd(firstIndex, firstIndex + newValues.size());
+    }
+
+    private void addRemove(ListChangeListener.Change<? extends F> c) {
+        int from = c.getFrom();
+        int to = c.getTo();
+
+        for (int index = from + c.getRemovedSize() - 1; index >= from; index--) {
+            int firstOldIndex = getFirstPosition(index);
+            int lastOldIndexPlusOne = getLastPosition(index);
+
+            removeSourceValue(index, firstOldIndex, lastOldIndexPlusOne);
+        }
+
+        for (int index = from; index < from + c.getAddedSize(); index++) {
+            int lastOldIndex = getLastPosition(index - 1);
+
+            addSourceValue(index, lastOldIndex);
+        }
+    }
+
+    @Override
+    protected void sourceChanged(ListChangeListener.Change<? extends F> c) {
+        beginChange();
+        while (c.next()) {
+            if (c.wasPermutated()) {
+                permutate(c);
+            } else if (c.wasUpdated()) {
+                update(c);
+            } else {
+                addRemove(c);
+            }
+        }
+        endChange();
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/MappedList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/MappedList.java
@@ -10,6 +10,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+/**
+ * Created by marc on 01.04.17.
+ */
 public class MappedList<E, F> extends TransformationList<E, F> {
     private final Function<? super F, ? extends E> mapper;
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/MappedList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/MappedList.java
@@ -1,0 +1,117 @@
+package org.phoenicis.javafx.views.common;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import javafx.collections.ListChangeListener.Change;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.TransformationList;
+
+public class MappedList<E, F> extends TransformationList<E, F> {
+    private final Map<? super F, E> mappedValues;
+
+    private final Function<? super F, ? extends E> mapper;
+
+    public MappedList(ObservableList<? extends F> source, Function<? super F, ? extends E> mapper) {
+        super(source);
+
+        this.mappedValues = new HashMap<F, E>();
+        this.mapper = mapper;
+    }
+
+    @Override
+    public int getSourceIndex(int index) {
+        return index;
+    }
+
+    @Override
+    public E get(int index) {
+        F sourceValue = getSource().get(index);
+        if (!this.mappedValues.containsKey(sourceValue)) {
+            this.mappedValues.put(sourceValue, mapper.apply(sourceValue));
+        }
+        return mappedValues.get(sourceValue);
+    }
+
+    @Override
+    public int size() {
+        return getSource().size();
+    }
+
+    @Override
+    protected void sourceChanged(Change<? extends F> c) {
+        fireChange(new Change<E>(this) {
+
+            @Override
+            public boolean wasAdded() {
+                return c.wasAdded();
+            }
+
+            @Override
+            public boolean wasRemoved() {
+                return c.wasRemoved();
+            }
+
+            @Override
+            public boolean wasReplaced() {
+                return c.wasReplaced();
+            }
+
+            @Override
+            public boolean wasUpdated() {
+                return c.wasUpdated();
+            }
+
+            @Override
+            public boolean wasPermutated() {
+                return c.wasPermutated();
+            }
+
+            @Override
+            public int getPermutation(int i) {
+                return c.getPermutation(i);
+            }
+
+            @Override
+            protected int[] getPermutation() {
+                // This method is only called by the superclass methods
+                // wasPermutated() and getPermutation(int), which are
+                // both overriden by this class. There is no other way
+                // this method can be called.
+                throw new AssertionError("Unreachable code");
+            }
+
+            @Override
+            public List<E> getRemoved() {
+                ArrayList<E> res = new ArrayList<>(c.getRemovedSize());
+                for(F e: c.getRemoved()) {
+                    res.add(mappedValues.get(e));
+                }
+                return res;
+            }
+
+            @Override
+            public int getFrom() {
+                return c.getFrom();
+            }
+
+            @Override
+            public int getTo() {
+                return c.getTo();
+            }
+
+            @Override
+            public boolean next() {
+                return c.next();
+            }
+
+            @Override
+            public void reset() {
+                c.reset();
+            }
+        });
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widget/MiniatureListWidget.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widget/MiniatureListWidget.java
@@ -34,9 +34,9 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import javafx.scene.shape.Rectangle;
-import org.fxmisc.easybind.EasyBind;
 import org.phoenicis.apps.dto.ApplicationDTO;
 import org.phoenicis.engines.dto.EngineVersionDTO;
+import org.phoenicis.javafx.views.common.MappedList;
 import org.phoenicis.library.dto.ShortcutDTO;
 
 import java.io.ByteArrayInputStream;
@@ -56,7 +56,7 @@ public final class MiniatureListWidget<E> extends ScrollPane {
 
         this.content = content;
         this.items = FXCollections.observableArrayList();
-        this.mappedElements = EasyBind.map(items, value -> {
+        this.mappedElements = new MappedList<Element<E>, E>(items, value -> {
             Element newElement = converter.apply(value);
 
             newElement.setOnMouseClicked(event -> setOnMouseClicked.accept(newElement, event));

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widget/MiniatureListWidget.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widget/MiniatureListWidget.java
@@ -34,6 +34,8 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import javafx.scene.shape.Rectangle;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.apps.dto.ApplicationDTO;
 import org.phoenicis.engines.dto.EngineVersionDTO;
 import org.phoenicis.javafx.views.common.MappedList;
@@ -190,19 +192,31 @@ public final class MiniatureListWidget<E> extends ScrollPane {
         }
 
         @Override
-        public int hashCode() {
-            return this.value.hashCode();
-        }
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
 
-        @Override
-        public boolean equals(Object other) {
-            if (!(other instanceof Element)) {
+            if (o == null || getClass() != o.getClass()) {
                 return false;
             }
 
-            Element<?> otherElement = (Element<?>) other;
+            Element<?> that = (Element<?>) o;
 
-            return this.value.equals(otherElement.value);
+            EqualsBuilder builder = new EqualsBuilder();
+
+            builder.append(value, that.value);
+
+            return builder.isEquals();
+        }
+
+        @Override
+        public int hashCode() {
+            HashCodeBuilder builder = new HashCodeBuilder();
+
+            builder.append(value);
+
+            return builder.toHashCode();
         }
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ViewApps.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ViewApps.java
@@ -34,6 +34,7 @@ import javafx.util.Duration;
 import org.phoenicis.apps.dto.ApplicationDTO;
 import org.phoenicis.apps.dto.CategoryDTO;
 import org.phoenicis.apps.dto.ScriptDTO;
+import org.phoenicis.javafx.views.common.ExpandedList;
 import org.phoenicis.javafx.views.common.ThemeManager;
 import org.phoenicis.javafx.views.common.widget.MiniatureListWidget;
 import org.phoenicis.javafx.views.mainwindow.MainWindowView;
@@ -80,27 +81,11 @@ public class ViewApps extends MainWindowView {
         this.installableCategories = this.categories.filtered(category -> category.getType() == CategoryDTO.CategoryType.INSTALLERS);
         this.sortedCategories = this.installableCategories.sorted(Comparator.comparing(CategoryDTO::getName));
 
-        this.applications = FXCollections.observableArrayList();
+        this.applications = new ExpandedList<ApplicationDTO, CategoryDTO>(this.installableCategories, CategoryDTO::getApplications);
         this.filteredApplications = new FilteredList<ApplicationDTO>(this.applications);
         this.sortedApplications = this.filteredApplications.sorted(Comparator.comparing(ApplicationDTO::getName));
 
         this.filter = new ApplicationFilter<ApplicationDTO>(filteredApplications, (filterText, application) -> application.getName().toLowerCase().contains(filterText));
-
-        this.installableCategories.addListener((ListChangeListener<? super CategoryDTO>) change -> {
-            while (change.next()) {
-                if (change.wasRemoved()) {
-                    for (CategoryDTO removedCategory : change.getRemoved()) {
-                        this.applications.removeAll(removedCategory.getApplications());
-                    }
-                }
-
-                if (change.wasAdded()) {
-                    for (CategoryDTO addedCategory : change.getAddedSubList()) {
-                        this.applications.addAll(addedCategory.getApplications());
-                    }
-                }
-            }
-        });
 
         Bindings.bindContent(this.categoryView.getElements(), this.sortedCategories);
         Bindings.bindContent(this.availableApps.getItems(), this.sortedApplications);

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/DragableRepositoryListCell.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/DragableRepositoryListCell.java
@@ -2,6 +2,7 @@ package org.phoenicis.javafx.views.mainwindow.settings;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -19,9 +20,9 @@ import javafx.scene.layout.GridPane;
  */
 public class DragableRepositoryListCell extends ListCell<String> implements ChangeListener<Number> {
 
-	private final Runnable onDragDone;
+	private final BiConsumer<String, Number> onDragDone;
 	
-	public DragableRepositoryListCell(Runnable onDragDone) {
+	public DragableRepositoryListCell(BiConsumer<String, Number> onDragDone) {
 		super();
 
 		this.onDragDone = onDragDone;
@@ -46,6 +47,8 @@ public class DragableRepositoryListCell extends ListCell<String> implements Chan
 
 		if (!empty) {
 			setGraphic(itemPane);
+		} else {
+			setGraphic(null);
 		}
 	}
 
@@ -105,7 +108,7 @@ public class DragableRepositoryListCell extends ListCell<String> implements Chan
 		});
 
 		setOnDragDone(event -> {
-			onDragDone.run();			
+			onDragDone.accept(getItem(), newValue);
 			
 			event.consume();
 		});

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
@@ -235,7 +235,7 @@ public class ViewSettings extends MainWindowView {
 		removeButton.setOnAction((ActionEvent event) -> {
 			String[] toRemove = repositoryListView.getSelectionModel().getSelectedItems().toArray(new String[0]);
 
-			repositories.removeAll(repositoryListView.getSelectionModel().getSelectedItems());
+			repositories.removeAll(toRemove);
 
 			this.save();
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleGroup.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleGroup.java
@@ -7,7 +7,7 @@ import javafx.scene.Node;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.VBox;
-import org.fxmisc.easybind.EasyBind;
+import org.phoenicis.javafx.views.common.MappedList;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -36,7 +36,7 @@ public class LeftToggleGroup<E> extends LeftGroup {
         this.toggleButtonBox.getStyleClass().add("leftPaneInside");
 
         this.elements = FXCollections.observableArrayList();
-        this.mappedToggleButtons = EasyBind.map(this.elements, value -> {
+        this.mappedToggleButtons = new MappedList<ToggleButton, E>(this.elements, value -> {
             ToggleButton button = converter.apply(value);
 
             button.setToggleGroup(toggleGroup);

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/ExpandedListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/ExpandedListTest.java
@@ -1,0 +1,138 @@
+package org.phoenicis.javafx.views.common;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Created by marc on 01.04.17.
+ */
+public class ExpandedListTest {
+    @Test
+    public void testListCreation() {
+        ObservableList<List<String>> observableList = FXCollections.observableArrayList(Arrays.asList("11"), Arrays.asList("21", "22"), Arrays.asList());
+        ExpandedList<String, List<String>> expandedList = new ExpandedList<>(observableList, Function.identity());
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+    }
+
+    @Test
+    public void testListAdd() {
+        ObservableList<List<String>> observableList = FXCollections.observableArrayList(Arrays.asList("11"), Arrays.asList("21", "22"), Arrays.asList());
+        ExpandedList<String, List<String>> expandedList = new ExpandedList<>(observableList, Function.identity());
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        observableList.add(1, Arrays.asList("01", "02"));
+
+        assertEquals(5, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("01", expandedList.get(1));
+        assertEquals("02", expandedList.get(2));
+        assertEquals("21", expandedList.get(3));
+        assertEquals("22", expandedList.get(4));
+    }
+
+    @Test
+    public void testListRemove1() {
+        ObservableList<List<String>> observableList = FXCollections.observableArrayList(Arrays.asList("11"), Arrays.asList("21", "22"), Arrays.asList());
+        ExpandedList<String, List<String>> expandedList = new ExpandedList<>(observableList, Function.identity());
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        observableList.remove(0);
+
+        assertEquals(2, expandedList.size());
+        assertEquals("21", expandedList.get(0));
+        assertEquals("22", expandedList.get(1));
+    }
+
+    @Test
+    public void testListRemove2() {
+        ObservableList<List<String>> observableList = FXCollections.observableArrayList(Arrays.asList("11"), Arrays.asList("21", "22"), Arrays.asList());
+        ExpandedList<String, List<String>> expandedList = new ExpandedList<>(observableList, Function.identity());
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        observableList.remove(1);
+
+        assertEquals(1, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+    }
+
+    @Test
+    public void testListRemove3() {
+        ObservableList<List<String>> observableList = FXCollections.observableArrayList(Arrays.asList("11"), Arrays.asList("21", "22"), Arrays.asList());
+        ExpandedList<String, List<String>> expandedList = new ExpandedList<>(observableList, Function.identity());
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        observableList.remove(2);
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+    }
+
+    @Test
+    public void testListUpdate() {
+        ObservableList<List<String>> observableList = FXCollections.observableArrayList(Arrays.asList("11"), Arrays.asList("21", "22"), Arrays.asList());
+        ExpandedList<String, List<String>> expandedList = new ExpandedList<>(observableList, Function.identity());
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        observableList.set(2, Arrays.asList("31", "32", "33"));
+
+        assertEquals(6, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+        assertEquals("31", expandedList.get(3));
+        assertEquals("32", expandedList.get(4));
+        assertEquals("33", expandedList.get(5));
+    }
+
+    @Test
+    public void testListPermutation() {
+        SortedList<List<String>> observableList = FXCollections.<List<String>>observableArrayList(Arrays.asList("11"), Arrays.asList("21", "22"), Arrays.asList()).sorted();
+        ExpandedList<String, List<String>> expandedList = new ExpandedList<>(observableList, Function.identity());
+
+        assertEquals(3, expandedList.size());
+        assertEquals("11", expandedList.get(0));
+        assertEquals("21", expandedList.get(1));
+        assertEquals("22", expandedList.get(2));
+
+        observableList.comparatorProperty().set(Comparator.comparing(o -> ((List<String>)o).size()).reversed());
+
+        assertEquals(3, expandedList.size());
+        assertEquals("21", expandedList.get(0));
+        assertEquals("22", expandedList.get(1));
+        assertEquals("11", expandedList.get(2));
+    }
+}

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/MappedListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/MappedListTest.java
@@ -14,6 +14,18 @@ import java.util.Comparator;
  */
 public class MappedListTest {
     @Test
+    public void testListCreation() {
+        ObservableList<Integer> observableList = FXCollections.observableArrayList(Arrays.asList(3, 7, 1, 5));
+        MappedList<String, Integer> mappedList = new MappedList<>(observableList, i -> String.valueOf(i));
+
+        assertEquals(4, mappedList.size());
+        assertEquals("3", mappedList.get(0));
+        assertEquals("7", mappedList.get(1));
+        assertEquals("1", mappedList.get(2));
+        assertEquals("5", mappedList.get(3));
+    }
+
+    @Test
     public void testListAdd() {
         ObservableList<Integer> observableList = FXCollections.observableArrayList(Arrays.asList(3, 7, 1, 5));
         MappedList<String, Integer> mappedList = new MappedList<>(observableList, i -> String.valueOf(i));

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/MappedListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/MappedListTest.java
@@ -1,0 +1,95 @@
+package org.phoenicis.javafx.views.common;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+/**
+ * Created by marc on 01.04.17.
+ */
+public class MappedListTest {
+    @Test
+    public void testListAdd() {
+        ObservableList<Integer> observableList = FXCollections.observableArrayList(Arrays.asList(3, 7, 1, 5));
+        MappedList<String, Integer> mappedList = new MappedList<>(observableList, i -> String.valueOf(i));
+
+        assertEquals(4, mappedList.size());
+        assertEquals("3", mappedList.get(0));
+        assertEquals("7", mappedList.get(1));
+        assertEquals("1", mappedList.get(2));
+        assertEquals("5", mappedList.get(3));
+
+        observableList.add(0);
+
+        assertEquals(5, mappedList.size());
+        assertEquals("3", mappedList.get(0));
+        assertEquals("7", mappedList.get(1));
+        assertEquals("1", mappedList.get(2));
+        assertEquals("5", mappedList.get(3));
+        assertEquals("0", mappedList.get(4));
+    }
+
+    @Test
+    public void testListRemove() {
+        ObservableList<Integer> observableList = FXCollections.observableArrayList(Arrays.asList(3, 7, 1, 5));
+        MappedList<String, Integer> mappedList = new MappedList<>(observableList, i -> String.valueOf(i));
+
+        assertEquals(4, mappedList.size());
+        assertEquals("3", mappedList.get(0));
+        assertEquals("7", mappedList.get(1));
+        assertEquals("1", mappedList.get(2));
+        assertEquals("5", mappedList.get(3));
+
+        observableList.remove(2);
+
+        assertEquals(3, mappedList.size());
+        assertEquals("3", mappedList.get(0));
+        assertEquals("7", mappedList.get(1));
+        assertEquals("5", mappedList.get(2));
+    }
+
+    @Test
+    public void testListUpdate() {
+        ObservableList<Integer> observableList = FXCollections.observableList(Arrays.asList(3, 7, 1, 5));
+        MappedList<String, Integer> mappedList = new MappedList<>(observableList, i -> String.valueOf(i));
+
+        assertEquals(4, mappedList.size());
+        assertEquals("3", mappedList.get(0));
+        assertEquals("7", mappedList.get(1));
+        assertEquals("1", mappedList.get(2));
+        assertEquals("5", mappedList.get(3));
+
+        observableList.set(2, 4);
+
+        assertEquals(4, mappedList.size());
+        assertEquals("3", mappedList.get(0));
+        assertEquals("7", mappedList.get(1));
+        assertEquals("4", mappedList.get(2));
+        assertEquals("5", mappedList.get(3));
+    }
+
+    @Test
+    public void testListPermutation() {
+        SortedList<Integer> sortedList = FXCollections.observableList(Arrays.asList(3, 7, 1, 5)).sorted();
+        MappedList<String, Integer> mappedList = new MappedList<>(sortedList, i -> String.valueOf(i));
+
+        assertEquals(4, mappedList.size());
+        assertEquals("1", mappedList.get(0));
+        assertEquals("3", mappedList.get(1));
+        assertEquals("5", mappedList.get(2));
+        assertEquals("7", mappedList.get(3));
+
+        sortedList.comparatorProperty().set(Comparator.comparing(String::valueOf).reversed());
+
+        assertEquals(4, mappedList.size());
+        assertEquals("7", mappedList.get(0));
+        assertEquals("5", mappedList.get(1));
+        assertEquals("3", mappedList.get(2));
+        assertEquals("1", mappedList.get(3));
+    }
+}

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/ScriptsConfiguration.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/ScriptsConfiguration.java
@@ -54,7 +54,7 @@ public class ScriptsConfiguration {
 
     @Bean
     public ScriptFetcher scriptFetcher() {
-        return new ScriptFetcher(appsConfiguration.repository());
+        return new ScriptFetcher(appsConfiguration.repositoryManager().cachedRepository());
     }
 
     @Bean


### PR DESCRIPTION
This PR enables POL 5 to process the following repository changes in the repository settings at runtime:

- The addition of a new repository through the "Add" button
- The removal of one or more repositories through the "Remove" button
- The permutation of two repositories through drag and drop

In addition this PR removes the `EasyBind` dependency again, because it doesn't remember its mappings. If you remove an element from the source list it creates a new mapping for the removed element and forwards it to its own bindings to be removed. Because the new mapping and the old mappings don't need to be equal (like for the category-`ToggleButton`s as an example), it's impossible to remove the old elements because they are not equal to the to be deleted ones.

The new `MappedList` implementation is based on the one in `EasyBind`, but it has currently the problem that it has a potential memory leak, because its map, that contains all done mappings, is never cleaned up, when one or more elements are to be deleted. 
If someone has a good idea of how to do this please tell me.

In addition to the previous stated points I've added `equals` and `hashCode` implementations to all `Repository` classes. If you have some ideas on how to improve these implementations, I'm open for suggestions.
