### PR TITLE
Fixing repository query call in PhoenixisTestsConfiguration

### DIFF
--- a/phoenicis-tests/src/main/java/org/phoenicis/tests/PhoenicisTestsConfiguration.java
+++ b/phoenicis-tests/src/main/java/org/phoenicis/tests/PhoenicisTestsConfiguration.java
@@ -48,7 +48,7 @@ class PhoenicisTestsConfiguration {
 
     @Bean
     public Repository mockedRepository() {
-        return new MockedRepository(appsConfiguration.repository());
+        return new MockedRepository(appsConfiguration.repositoryManager().cachedRepository());
     }
 
 }


### PR DESCRIPTION
This PR updates a missed `appsConfiguration.repository()` method call, from PR #688.

I'm not sure how I missed this, because I did run `mvn test` before/after pushing my commits, which, as far as I remember, did result in a `BUILD SUCCESS`....