### PR TITLE
New repositories are now added as the ones with the highest priority

### DIFF
--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/MultipleRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/MultipleRepository.java
@@ -78,6 +78,17 @@ class MultipleRepository extends MergeableRepository {
 		this.repositories = newRepositories;
 	}
 
+	public void addRepository(int index, Repository repository) {
+		Repository[] newRepositories = new Repository[this.repositories.length + 1];
+
+		System.arraycopy(this.repositories, 0, newRepositories, 1, index);
+		System.arraycopy(this.repositories, index, newRepositories, 1 + index, this.repositories.length - index);
+
+		newRepositories[index] = repository;
+
+		this.repositories = newRepositories;
+	}
+
 	public void removeRepository(Repository repository) {
 		int index = Arrays.asList(this.repositories).indexOf(repository);
 

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/RepositoryManager.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/RepositoryManager.java
@@ -85,6 +85,12 @@ public class RepositoryManager {
         this.triggerRepositoryChange();
     }
 
+    public void addRepository(int index, String repositoryUrl) {
+        LOGGER.info(String.format("Adding repository: %s at index %d", repositoryUrl, index));
+        this.multipleRepository.addRepository(index, toRepository(repositoryUrl));
+        this.triggerRepositoryChange();
+    }
+
     public void removeRepositories(String ... repositoryUrls) {
         LOGGER.info(String.format("Removing repositories: %s", Arrays.toString(repositoryUrls)));
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
@@ -209,6 +209,8 @@ public class ViewSettings extends MainWindowView {
 		repositoryListView.setEditable(true);
 		repositoryListView.setCellFactory(param -> new DragableRepositoryListCell((repositoryUrl, toIndex) -> {
 			this.repositoryManager.moveRepository(repositoryUrl, toIndex.intValue());
+
+			this.save();
 		}));
 		HBox repositoryButtonLayout = new HBox();
 		repositoryButtonLayout.setSpacing(5);
@@ -223,11 +225,11 @@ public class ViewSettings extends MainWindowView {
 
 			Optional<String> result = dialog.showAndWait();
 			result.ifPresent(newRepository -> {
-				repositories.add(newRepository);
+				repositories.add(0, newRepository);
 
 				this.save();
 
-				repositoryManager.addRepository(newRepository);
+				repositoryManager.addRepository(0, newRepository);
 			});
 		});
 		Button removeButton = new Button();


### PR DESCRIPTION
This PR changes the priority of new repositories. 
Previously a new repository were added as the repository with the lowest priority, now they get the highest priority.
In addition this PR fixes a bug, that the repository order wasn't saved to disk after the order has been changed.

The current implementation (including the introduced changes in this PR) of the `MultipleRepository` and the `TeeRepository` contradict the information of the Repository page in the wiki, because currently it seems like the most important repository is at the beginning of the list and not at the end.
This behavior already existed before PR #657, which modified both `MultipleRepository` and `TeeRepository`. The root cause for this is line 92 in `MergeableRepository` where the parameters in the `mergeApplications` call are swapped. This was already the case before PR #657.
Should we stay with the current behavior, that the first entry in the list has the highest priority and modify the wiki to go along with this, or should we change the implementation, that it fits to the wiki?