### PR TITLE
Remove the access to the cached repository from outside the RepositoryManager

### DIFF
--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/AppsConfiguration.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/AppsConfiguration.java
@@ -50,7 +50,7 @@ public class AppsConfiguration {
 
     @Bean
     public RepositoryManager repositoryManager() {
-        RepositoryManager repositoryManager = new RepositoryManager(multithreadingConfiguration.appsExecutorService(), enforceUncompatibleOperatingSystems, toolsConfiguration, cacheDirectoryPath, fileUtilities,
+        RepositoryManager repositoryManager = new DefaultRepositoryManager(multithreadingConfiguration.appsExecutorService(), enforceUncompatibleOperatingSystems, toolsConfiguration, cacheDirectoryPath, fileUtilities,
                 new LocalRepository.Factory(objectMapper()), new ClasspathRepository.Factory(objectMapper(), new PathMatchingResourcePatternResolver()));
 
         // set initial repositories

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/DefaultRepositoryManager.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/DefaultRepositoryManager.java
@@ -1,0 +1,144 @@
+package org.phoenicis.apps;
+
+import org.phoenicis.apps.dto.ApplicationDTO;
+import org.phoenicis.apps.dto.CategoryDTO;
+import org.phoenicis.apps.dto.ScriptDTO;
+import org.phoenicis.tools.ToolsConfiguration;
+import org.phoenicis.tools.files.FileUtilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * Created by marc on 31.03.17.
+ */
+public class DefaultRepositoryManager implements RepositoryManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRepositoryManager.class);
+
+    private final LocalRepository.Factory localRepositoryFactory;
+    private final ClasspathRepository.Factory classPathRepositoryFactory;
+    private final String cacheDirectoryPath;
+
+    private final FileUtilities fileUtilities;
+
+    private MultipleRepository multipleRepository;
+    private FilterRepository filterRepository;
+    private CachedRepository cachedRepository;
+    private BackgroundRepository backgroundRepository;
+
+    private List<CallbackPair> callbacks;
+
+    public DefaultRepositoryManager(ExecutorService executorService, boolean enforceUncompatibleOperatingSystems, ToolsConfiguration toolsConfiguration, String cacheDirectoryPath, FileUtilities fileUtilities, LocalRepository.Factory localRepositoryFactory, ClasspathRepository.Factory classPathRepositoryFactory) {
+        super();
+
+        this.localRepositoryFactory = localRepositoryFactory;
+        this.classPathRepositoryFactory = classPathRepositoryFactory;
+        this.cacheDirectoryPath = cacheDirectoryPath;
+        this.fileUtilities = fileUtilities;
+
+        this.callbacks = new ArrayList<CallbackPair>();
+
+        this.multipleRepository = new MultipleRepository();
+        this.filterRepository = new FilterRepository(multipleRepository, toolsConfiguration.operatingSystemFetcher(), enforceUncompatibleOperatingSystems);
+        this.cachedRepository = new CachedRepository(filterRepository);
+        this.backgroundRepository = new BackgroundRepository(cachedRepository, executorService);
+    }
+
+    @Override
+    public void addCallbacks(Consumer<List<CategoryDTO>> onRepositoryChange, Consumer<Exception> onError) {
+        this.callbacks.add(new CallbackPair(onRepositoryChange, onError));
+    }
+
+    public ApplicationDTO getApplication(List<String> path) {
+        return this.cachedRepository.getApplication(path);
+    }
+
+    public ScriptDTO getScript(List<String> path) {
+        return this.cachedRepository.getScript(path);
+    }
+
+    public void moveRepository(String repositoryUrl, int toIndex) {
+        LOGGER.info(String.format("Move repository: %s to %d", repositoryUrl, toIndex));
+        this.multipleRepository.moveRepository(toRepository(repositoryUrl), toIndex);
+        this.triggerRepositoryChange();
+    }
+
+    public void addRepositories(String ... repositoryUrls) {
+        LOGGER.info(String.format("Adding repositories: %s", Arrays.toString(repositoryUrls)));
+        Arrays.stream(repositoryUrls).map(this::toRepository).forEach(this.multipleRepository::addRepository);
+        this.triggerRepositoryChange();
+    }
+
+
+    public void removeRepositories(String ... repositoryUrls) {
+        LOGGER.info(String.format("Removing repositories: %s", Arrays.toString(repositoryUrls)));
+
+        List<Repository> toDeleteRepositories = Arrays.stream(repositoryUrls).map(this::toRepository).collect(Collectors.toList());
+        toDeleteRepositories.forEach(this.multipleRepository::removeRepository);
+
+        this.triggerRepositoryChange();
+
+        toDeleteRepositories.forEach(Repository::onDelete);
+    }
+
+    public void triggerRepositoryChange() {
+        this.cachedRepository.clearCache();
+
+        if (!this.callbacks.isEmpty()) {
+            this.backgroundRepository.fetchInstallableApplications(
+                    categories -> this.callbacks.forEach(callbackPair -> callbackPair.getOnRepositoryChange().accept(categories)),
+                    exception -> this.callbacks.forEach(callbackPair -> callbackPair.getOnError().accept(exception)));
+        }
+    }
+
+    private Repository toRepository(String repositoryUrl) {
+        LOGGER.info("Converting: " + repositoryUrl + " to Repository");
+        try {
+            final URI url = new URI(repositoryUrl);
+            final String scheme = url.getScheme().split("\\+")[0];
+
+            switch (scheme) {
+                case "git":
+                    return new GitRepository(repositoryUrl.replace("git+",""), cacheDirectoryPath,
+                            localRepositoryFactory, fileUtilities);
+                case "file":
+                    return localRepositoryFactory.createInstance(url.getRawPath());
+                case "classpath":
+                    return classPathRepositoryFactory.createInstance(url.getPath());
+                default:
+                    LOGGER.warn("Unsupported URL: " + repositoryUrl);
+                    return new NullRepository();
+            }
+        } catch (URISyntaxException e) {
+            LOGGER.warn("Cannot parse URL: " + repositoryUrl, e);
+            return new NullRepository();
+        }
+    }
+
+    private class CallbackPair {
+        private Consumer<List<CategoryDTO>> onRepositoryChange;
+
+        private Consumer<Exception> onError;
+
+        public CallbackPair(Consumer<List<CategoryDTO>> onRepositoryChange, Consumer<Exception> onError) {
+            this.onRepositoryChange = onRepositoryChange;
+            this.onError = onError;
+        }
+
+        public Consumer<List<CategoryDTO>> getOnRepositoryChange() {
+            return this.onRepositoryChange;
+        }
+
+        public Consumer<Exception> getOnError() {
+            return this.onError;
+        }
+    }
+}

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/NullRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/NullRepository.java
@@ -23,7 +23,7 @@ import org.phoenicis.apps.dto.CategoryDTO;
 import java.util.Collections;
 import java.util.List;
 
-class NullRepository implements Repository {
+public class NullRepository implements Repository {
     @Override
     public List<CategoryDTO> fetchInstallableApplications() {
         return Collections.emptyList();

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/RepositoryManager.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/RepositoryManager.java
@@ -1,6 +1,8 @@
 package org.phoenicis.apps;
 
+import org.phoenicis.apps.dto.ApplicationDTO;
 import org.phoenicis.apps.dto.CategoryDTO;
+import org.phoenicis.apps.dto.ScriptDTO;
 import org.phoenicis.multithreading.ControlledThreadPoolExecutorService;
 import org.phoenicis.tools.ToolsConfiguration;
 import org.phoenicis.tools.files.FileUtilities;
@@ -57,8 +59,12 @@ public class RepositoryManager {
         this.onError = onError;
     }
 
-    public Repository cachedRepository() {
-        return this.cachedRepository;
+    public ApplicationDTO getApplication(List<String> path) {
+        return this.cachedRepository.getApplication(path);
+    }
+
+    public ScriptDTO getScript(List<String> path) {
+        return this.cachedRepository.getScript(path);
     }
 
     @Deprecated

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/apps/AppsController.java
@@ -39,8 +39,7 @@ public class AppsController {
         this.repositoryManager = repositoryManager;
         this.scriptInterpreter = scriptInterpreter;
 
-        this.repositoryManager.setOnRepositoryChange(this.view::populate);
-        this.repositoryManager.setOnError(e -> this.view.showFailure());
+        this.repositoryManager.addCallbacks(view::populate, e -> view.showFailure());
     }
 
     public void loadApps() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
@@ -227,7 +227,7 @@ public class ViewSettings extends MainWindowView {
 
 				this.save();
 
-				repositoryManager.addRepository(newRepository);
+				repositoryManager.addRepositories(newRepository);
 			});
 		});
 		Button removeButton = new Button();

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/ScriptsConfiguration.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/ScriptsConfiguration.java
@@ -54,7 +54,7 @@ public class ScriptsConfiguration {
 
     @Bean
     public ScriptFetcher scriptFetcher() {
-        return new ScriptFetcher(appsConfiguration.repositoryManager().cachedRepository());
+        return new ScriptFetcher(appsConfiguration.repositoryManager());
     }
 
     @Bean

--- a/phoenicis-scripts/src/main/java/org/phoenicis/scripts/interpreter/ScriptFetcher.java
+++ b/phoenicis-scripts/src/main/java/org/phoenicis/scripts/interpreter/ScriptFetcher.java
@@ -18,21 +18,21 @@
 
 package org.phoenicis.scripts.interpreter;
 
-import org.phoenicis.apps.Repository;
+import org.phoenicis.apps.RepositoryManager;
 import org.phoenicis.apps.dto.ScriptDTO;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class ScriptFetcher {
-    private final Repository repository;
+    private final RepositoryManager repositoryManager;
 
-    public ScriptFetcher(Repository repository) {
-        this.repository = repository;
+    public ScriptFetcher(RepositoryManager repositoryManager) {
+        this.repositoryManager = repositoryManager;
     }
 
     public String getScript(List<String> path) {
-        final ScriptDTO script = repository.getScript(path);
+        final ScriptDTO script = repositoryManager.getScript(path);
 
         if (script == null) {
             throw new ScriptException("Script not found: " + path);

--- a/phoenicis-tests/src/main/java/org/phoenicis/tests/PhoenicisTestsConfiguration.java
+++ b/phoenicis-tests/src/main/java/org/phoenicis/tests/PhoenicisTestsConfiguration.java
@@ -18,8 +18,9 @@
 
 package org.phoenicis.tests;
 
-import org.phoenicis.apps.Repository;
 import org.phoenicis.apps.AppsConfiguration;
+import org.phoenicis.apps.NullRepository;
+import org.phoenicis.apps.Repository;
 import org.phoenicis.configuration.PhoenicisGlobalConfiguration;
 import org.phoenicis.multithreading.MultithreadingConfiguration;
 import org.phoenicis.scripts.ScriptsConfiguration;
@@ -48,7 +49,7 @@ class PhoenicisTestsConfiguration {
 
     @Bean
     public Repository mockedRepository() {
-        return new MockedRepository(appsConfiguration.repositoryManager().cachedRepository());
+        return new MockedRepository(new NullRepository());
     }
 
 }


### PR DESCRIPTION
This PR removes the access to the `CacheRepository` in the `RepositoryManager` from outside.
This is needed, because we can't be sure that the repository structure of POL 5 will look like it currently does at a later time.

On another note:
What is the reason for the `MockedRepository` class extending a `TeeRepository`? Wouldn't it be better to directly return an instance of `MockRepository`?