### PR TITLE
Make the engine version of a container changeable

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/ControllerConfiguration.java
@@ -89,7 +89,8 @@ public class ControllerConfiguration {
                 viewsConfiguration.viewContainers(),
                 containersConfiguration.backgroundContainersManager(),
                 viewsConfiguration.winePrefixContainerPanelFactory(),
-                containersConfiguration.winePrefixContainerController()
+                containersConfiguration.winePrefixContainerController(),
+                enginesConfiguration.wineVersionsFetcher()
         );
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
@@ -18,30 +18,38 @@
 
 package org.phoenicis.javafx.controller.containers;
 
+import com.sun.xml.internal.ws.api.pipe.Engine;
+import javafx.application.Platform;
 import org.phoenicis.containers.ContainersManager;
 import org.phoenicis.containers.dto.ContainerDTO;
 import org.phoenicis.containers.dto.WinePrefixContainerDTO;
 import org.phoenicis.containers.wine.WinePrefixContainerController;
+import org.phoenicis.engines.EnginesSource;
+import org.phoenicis.engines.dto.EngineVersionDTO;
 import org.phoenicis.javafx.views.common.ConfirmMessage;
 import org.phoenicis.javafx.views.common.ErrorMessage;
 import org.phoenicis.javafx.views.mainwindow.containers.ContainerPanelFactory;
 import org.phoenicis.javafx.views.mainwindow.containers.ViewContainers;
 import org.phoenicis.javafx.views.mainwindow.containers.WinePrefixContainerPanel;
-import javafx.application.Platform;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ContainersController {
     private final ViewContainers viewContainers;
     private final ContainersManager containersManager;
     private final ContainerPanelFactory<WinePrefixContainerPanel, WinePrefixContainerDTO> winePrefixContainerPanelFactory;
     private final WinePrefixContainerController winePrefixContainerController;
+    private final EnginesSource enginesSource;
 
     public ContainersController(ViewContainers viewContainers,
                                 ContainersManager containersManager,
-                                ContainerPanelFactory<WinePrefixContainerPanel, WinePrefixContainerDTO> winePrefixContainerPanelFactory, WinePrefixContainerController winePrefixContainerController) {
+                                ContainerPanelFactory<WinePrefixContainerPanel, WinePrefixContainerDTO> winePrefixContainerPanelFactory, WinePrefixContainerController winePrefixContainerController, EnginesSource enginesSource) {
         this.viewContainers = viewContainers;
         this.containersManager = containersManager;
         this.winePrefixContainerPanelFactory = winePrefixContainerPanelFactory;
         this.winePrefixContainerController = winePrefixContainerController;
+        this.enginesSource = enginesSource;
 
         viewContainers.setOnSelectionChanged(event -> {
             if (viewContainers.isSelected()) {
@@ -50,85 +58,87 @@ public class ContainersController {
         });
 
         viewContainers.setOnSelectContainer((ContainerDTO containerDTO) -> {
-            final WinePrefixContainerPanel panel = winePrefixContainerPanelFactory.createContainerPanel((WinePrefixContainerDTO) containerDTO, viewContainers.getThemeManager());
-            panel.setOnWineCfg(winePrefixDTO -> winePrefixContainerController.runInPrefix(
-                    winePrefixDTO,
-                    "winecfg",
-                    panel::unlockAll,
-                    e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
-            );
-
-            panel.setOnRegedit(winePrefixDTO -> winePrefixContainerController.runInPrefix(
-                    winePrefixDTO,
-                    "regedit",
-                    panel::unlockAll,
-                    e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
-            );
-
-            panel.setOnWineboot(winePrefixDTO -> winePrefixContainerController.runInPrefix(
-                    winePrefixDTO,
-                    "wineboot",
-                    panel::unlockAll,
-                    e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
-            );
-
-            panel.setOnWinebootRepair(winePrefixDTO -> winePrefixContainerController.repairPrefix(
-                    winePrefixDTO,
-                    panel::unlockAll,
-                    e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
-            );
-
-            panel.setOnWineConsole(winePrefixDTO -> winePrefixContainerController.runInPrefix(
-                    winePrefixDTO,
-                    "wineconsole",
-                    panel::unlockAll,
-                    e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
-            );
-
-            panel.setOnTaskMgr(winePrefixDTO -> winePrefixContainerController.runInPrefix(
-                    winePrefixDTO,
-                    "taskmgr",
-                    panel::unlockAll,
-                    e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
-            );
-
-            panel.setOnUninstaller(winePrefixDTO -> winePrefixContainerController.runInPrefix(
-                    winePrefixDTO,
-                    "uninstaller",
-                    panel::unlockAll,
-                    e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
-            );
-
-            panel.setOnKillProcess(winePrefixDTO -> winePrefixContainerController.killProcesses(
-                    winePrefixDTO,
-                    panel::unlockAll,
-                    e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
-            );
-
-            panel.setOnOpenTerminalInWinePrefix(winePrefix -> {
-                winePrefixContainerController.openTerminalInPrefix(winePrefix);
-                panel.unlockAll();
-            });
-
-            panel.setOnChangeSetting((winePrefixDTO, setting) -> {
-                winePrefixContainerController.changeSetting(
+            enginesSource.fetchAvailableEngines(engineCategoryDTOS -> {
+                final WinePrefixContainerPanel panel = winePrefixContainerPanelFactory.createContainerPanel((WinePrefixContainerDTO) containerDTO, viewContainers.getThemeManager(), engineCategoryDTOS.stream().flatMap(category -> category.getSubCategories().stream()).flatMap(subCategory -> subCategory.getPackages().stream()).collect(Collectors.toList()));
+                panel.setOnWineCfg(winePrefixDTO -> winePrefixContainerController.runInPrefix(
                         winePrefixDTO,
-                        setting,
+                        "winecfg",
                         panel::unlockAll,
-                        e -> Platform.runLater(() -> new ErrorMessage("Error", e).show())
+                        e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
                 );
-                panel.unlockAll();
-            });
 
-            panel.setOnDeletePrefix(winePrefixDTO -> {
-                new ConfirmMessage("Delete " + winePrefixDTO.getName() + " container", "Are you sure you want to delete the " + winePrefixDTO.getName() + " container?")
-                        .ask(() -> {
-                            winePrefixContainerController.deletePrefix(winePrefixDTO, e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
-                            loadContainers();
-                        });
-            });
+                panel.setOnRegedit(winePrefixDTO -> winePrefixContainerController.runInPrefix(
+                        winePrefixDTO,
+                        "regedit",
+                        panel::unlockAll,
+                        e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
+                );
 
-            viewContainers.showRightView(panel);
+                panel.setOnWineboot(winePrefixDTO -> winePrefixContainerController.runInPrefix(
+                        winePrefixDTO,
+                        "wineboot",
+                        panel::unlockAll,
+                        e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
+                );
+
+                panel.setOnWinebootRepair(winePrefixDTO -> winePrefixContainerController.repairPrefix(
+                        winePrefixDTO,
+                        panel::unlockAll,
+                        e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
+                );
+
+                panel.setOnWineConsole(winePrefixDTO -> winePrefixContainerController.runInPrefix(
+                        winePrefixDTO,
+                        "wineconsole",
+                        panel::unlockAll,
+                        e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
+                );
+
+                panel.setOnTaskMgr(winePrefixDTO -> winePrefixContainerController.runInPrefix(
+                        winePrefixDTO,
+                        "taskmgr",
+                        panel::unlockAll,
+                        e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
+                );
+
+                panel.setOnUninstaller(winePrefixDTO -> winePrefixContainerController.runInPrefix(
+                        winePrefixDTO,
+                        "uninstaller",
+                        panel::unlockAll,
+                        e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
+                );
+
+                panel.setOnKillProcess(winePrefixDTO -> winePrefixContainerController.killProcesses(
+                        winePrefixDTO,
+                        panel::unlockAll,
+                        e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()))
+                );
+
+                panel.setOnOpenTerminalInWinePrefix(winePrefix -> {
+                    winePrefixContainerController.openTerminalInPrefix(winePrefix);
+                    panel.unlockAll();
+                });
+
+                panel.setOnChangeSetting((winePrefixDTO, setting) -> {
+                    winePrefixContainerController.changeSetting(
+                            winePrefixDTO,
+                            setting,
+                            panel::unlockAll,
+                            e -> Platform.runLater(() -> new ErrorMessage("Error", e).show())
+                    );
+                    panel.unlockAll();
+                });
+
+                panel.setOnDeletePrefix(winePrefixDTO -> {
+                    new ConfirmMessage("Delete " + winePrefixDTO.getName() + " container", "Are you sure you want to delete the " + winePrefixDTO.getName() + " container?")
+                            .ask(() -> {
+                                winePrefixContainerController.deletePrefix(winePrefixDTO, e -> Platform.runLater(() -> new ErrorMessage("Error", e).show()));
+                                loadContainers();
+                            });
+                });
+
+                Platform.runLater(() -> viewContainers.showRightView(panel));
+            });
         });
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/AbstractContainerPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/AbstractContainerPanel.java
@@ -21,6 +21,7 @@ package org.phoenicis.javafx.views.mainwindow.containers;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.layout.VBox;
+import org.phoenicis.engines.dto.EngineVersionDTO;
 import org.phoenicis.javafx.views.common.ThemeManager;
 
 import java.util.List;
@@ -29,17 +30,17 @@ abstract class AbstractContainerPanel<T> extends VBox {
     protected final ThemeManager themeManager;
     private final TabPane tabPane;
 
-    AbstractContainerPanel(T containerEntity, ThemeManager themeManager) {
+    AbstractContainerPanel(T containerEntity, ThemeManager themeManager, List<EngineVersionDTO> engineVersions) {
         this.themeManager = themeManager;
         this.tabPane = new TabPane();
 
         this.getChildren().add(tabPane);
 
         this.getStyleClass().add("rightPane");
-        this.tabPane.getTabs().add(drawInformationTab(containerEntity));
+        this.tabPane.getTabs().add(drawInformationTab(containerEntity, engineVersions));
     }
 
-    abstract Tab drawInformationTab(T container);
+    abstract Tab drawInformationTab(T container, List<EngineVersionDTO> engineVersions);
 
     public List<Tab> getTabs() {
         return tabPane.getTabs();

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerPanelFactory.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerPanelFactory.java
@@ -19,9 +19,11 @@
 package org.phoenicis.javafx.views.mainwindow.containers;
 
 import org.phoenicis.containers.dto.ContainerDTO;
+import org.phoenicis.engines.dto.EngineVersionDTO;
 import org.phoenicis.javafx.views.common.ThemeManager;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 
 public class ContainerPanelFactory<T extends AbstractContainerPanel<C>, C extends ContainerDTO> {
     private final Class<T> clazz;
@@ -32,9 +34,9 @@ public class ContainerPanelFactory<T extends AbstractContainerPanel<C>, C extend
         this.entityClazz = entityClazz;
     }
 
-    public T createContainerPanel(C containerDTO, ThemeManager themeManager) {
+    public T createContainerPanel(C containerDTO, ThemeManager themeManager, List<EngineVersionDTO> engineVersions) {
         try {
-            return this.clazz.getConstructor(entityClazz, ThemeManager.class).newInstance(containerDTO, themeManager);
+            return this.clazz.getConstructor(entityClazz, ThemeManager.class, List.class).newInstance(containerDTO, themeManager, engineVersions);
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             throw new IllegalStateException(e);
         }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/WinePrefixContainerPanel.java
@@ -18,8 +18,13 @@
 
 package org.phoenicis.javafx.views.mainwindow.containers;
 
+import javafx.collections.FXCollections;
+import javafx.scene.control.*;
+import javafx.util.StringConverter;
 import org.phoenicis.containers.dto.WinePrefixContainerDTO;
 import org.phoenicis.containers.wine.parameters.*;
+import org.phoenicis.engines.EnginesSource;
+import org.phoenicis.engines.dto.EngineVersionDTO;
 import org.phoenicis.javafx.views.common.ColumnConstraintsWithPercentage;
 import org.phoenicis.javafx.views.common.TextWithStyle;
 import com.sun.javafx.collections.ImmutableObservableList;
@@ -29,10 +34,6 @@ import javafx.event.EventHandler;
 import javafx.geometry.HPos;
 import javafx.geometry.VPos;
 import javafx.scene.Node;
-import javafx.scene.control.Button;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.Label;
-import javafx.scene.control.Tab;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.*;
 import javafx.scene.text.Text;
@@ -65,8 +66,8 @@ public class WinePrefixContainerPanel extends AbstractContainerPanel<WinePrefixC
 
     private BiConsumer<WinePrefixContainerDTO, RegistryParameter> onChangeSetting = (winePrefix, value) -> {};
 
-    public WinePrefixContainerPanel(WinePrefixContainerDTO containerEntity, ThemeManager themeManager) {
-        super(containerEntity, themeManager);
+    public WinePrefixContainerPanel(WinePrefixContainerDTO containerEntity, ThemeManager themeManager, List<EngineVersionDTO> engineVersions) {
+        super(containerEntity, themeManager, engineVersions);
         this.getTabs().add(drawDisplayTab(containerEntity));
         this.getTabs().add(drawInputTab(containerEntity));
         this.getTabs().add(drawWineToolsTab(containerEntity));
@@ -78,7 +79,7 @@ public class WinePrefixContainerPanel extends AbstractContainerPanel<WinePrefixC
     }
 
     @Override
-    Tab drawInformationTab(WinePrefixContainerDTO container) {
+    Tab drawInformationTab(WinePrefixContainerDTO container, List<EngineVersionDTO> engineVersions) {
         final Tab informationTab = new Tab(translate("Information"));
         final VBox informationPane = new VBox();
         final Text title = new TextWithStyle(translate("Information"), TITLE_CSS_CLASS);
@@ -117,14 +118,30 @@ public class WinePrefixContainerPanel extends AbstractContainerPanel<WinePrefixC
         informationContentPane.setHgap(20);
         informationContentPane.setVgap(10);
 
+        informationPane.setSpacing(10);
+
         Region spacer = new Region();
-        spacer.setPrefHeight(30);
+        spacer.setPrefHeight(20);
         VBox.setVgrow(spacer, Priority.NEVER);
+
+        ComboBox<EngineVersionDTO> changeEngineComboBox = new ComboBox<EngineVersionDTO>(FXCollections.observableList(engineVersions));
+        changeEngineComboBox.setConverter(new StringConverter<EngineVersionDTO>() {
+            @Override
+            public String toString(EngineVersionDTO object) {
+                return object.getVersion();
+            }
+
+            @Override
+            public EngineVersionDTO fromString(String string) {
+                return engineVersions.stream().filter(engineVersion -> engineVersion.getVersion().equals(string)).findFirst().get();
+            }
+        });
+        changeEngineComboBox.getSelectionModel().select(engineVersions.stream().filter(engineVersion -> engineVersion.getVersion().equals(container.getVersion())).findFirst().get());
 
         Button deleteButton = new Button("Delete container");
         deleteButton.setOnMouseClicked(event -> this.deletePrefix(container));
 
-        informationPane.getChildren().addAll(informationContentPane, spacer, deleteButton);
+        informationPane.getChildren().addAll(informationContentPane, spacer, changeEngineComboBox, deleteButton);
         informationTab.setContent(informationPane);
         informationTab.setClosable(false);
         return informationTab;


### PR DESCRIPTION
This PR adds a ComboBox to the information tab in the `WinePrefixContainerPanel`, that enables the user to change the engine version of an existing container.
After opening the container details the engine version ComboBox will automatically show the currently selected engine version.

![grafik](https://cloud.githubusercontent.com/assets/18488086/24815785/bfeafe12-1bd6-11e7-8a36-9ad2c785e503.png)

**This PR is currently only a proof of concept and shouldn't be merged, because it is incomplete and has a few design problems in my eyes!**
For more information see #625.

