### PR TITLE
Fixed a bug that a dependency couldn't be found

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
@@ -18,21 +18,18 @@
 
 package org.phoenicis.javafx.controller.containers;
 
-import com.sun.xml.internal.ws.api.pipe.Engine;
 import javafx.application.Platform;
 import org.phoenicis.containers.ContainersManager;
 import org.phoenicis.containers.dto.ContainerDTO;
 import org.phoenicis.containers.dto.WinePrefixContainerDTO;
 import org.phoenicis.containers.wine.WinePrefixContainerController;
 import org.phoenicis.engines.EnginesSource;
-import org.phoenicis.engines.dto.EngineVersionDTO;
 import org.phoenicis.javafx.views.common.ConfirmMessage;
 import org.phoenicis.javafx.views.common.ErrorMessage;
 import org.phoenicis.javafx.views.mainwindow.containers.ContainerPanelFactory;
 import org.phoenicis.javafx.views.mainwindow.containers.ViewContainers;
 import org.phoenicis.javafx.views.mainwindow.containers.WinePrefixContainerPanel;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 public class ContainersController {


### PR DESCRIPTION
When running `mvn clean test` on the master branch I get:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project phoenicis-javafx: Compilation failure
[ERROR] /home/marc/Dokumente/Play on Linux/POL-POM-5/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java:[21,40] package com.sun.xml.internal.ws.api.pipe does not exist
```
This PR should fix this.
 