### PR TITLE
fixed MappedListTest

### DIFF
--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/MappedListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/MappedListTest.java
@@ -4,6 +4,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
 import org.junit.Test;
+import org.junit.Ignore;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;


### PR DESCRIPTION
Hi guys!

The current version does not build (at least on Arch Linux) because of a missing import in MappedListTest.java.

I've fixed that and now it works.