### PR TITLE
Replaced the array in MultipleRepository with a list

### DIFF
--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/MergeableRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/MergeableRepository.java
@@ -42,8 +42,8 @@ public abstract class MergeableRepository implements Repository {
 	 *         returned
 	 */
 	protected List<CategoryDTO> mergeRepositories(Map<Repository, List<CategoryDTO>> categoriesMap,
-			Repository... repositories) {
-		int numberOfRepositories = repositories.length;
+			List<Repository> repositories) {
+		int numberOfRepositories = repositories.size();
 
 		if (numberOfRepositories == 0) {
 			return Collections.emptyList();
@@ -53,12 +53,12 @@ public abstract class MergeableRepository implements Repository {
 		 * Take the first application source, from behind, as the default one
 		 */
 		final Map<String, CategoryDTO> mergedCategories = createSortedMap(
-				categoriesMap.get(repositories[numberOfRepositories - 1]), CategoryDTO::getName);
+				categoriesMap.get(repositories.get(numberOfRepositories - 1)), CategoryDTO::getName);
 
 		for (int otherRepositoryIndex = numberOfRepositories
 				- 2; otherRepositoryIndex >= 0; otherRepositoryIndex--) {
 			final List<CategoryDTO> otherCategories = categoriesMap
-					.get(repositories[otherRepositoryIndex]);
+					.get(repositories.get(otherRepositoryIndex));
 
 			final Map<String, CategoryDTO> otherCategoriesMap = createSortedMap(otherCategories, CategoryDTO::getName);
 

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/TeeRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/TeeRepository.java
@@ -18,14 +18,14 @@
 
 package org.phoenicis.apps;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.phoenicis.apps.dto.CategoryDTO;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.phoenicis.apps.dto.CategoryDTO;
 
 public class TeeRepository extends MergeableRepository {
     private final Repository leftRepository;
@@ -49,7 +49,7 @@ public class TeeRepository extends MergeableRepository {
     			.collect(
 						Collectors.toMap(source -> source, Repository::fetchInstallableApplications));
     	
-    	return mergeRepositories(categoriesMap, leftRepository, rightRepository);
+    	return mergeRepositories(categoriesMap, Arrays.asList(leftRepository, rightRepository));
     }
 
     @Override

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/MappedListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/MappedListTest.java
@@ -3,6 +3,7 @@ package org.phoenicis.javafx.views.common;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
+import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
This PR replaces the array used in `MultipleRepository` with a list and should therefore fix #701.
In addition this PR adds the missing `Ignore` import in `MappedListTest`.