### PR TITLE
Refactoring and improving the engine side bar

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/MainWindow.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/MainWindow.java
@@ -74,12 +74,6 @@ public class MainWindow extends Stage {
         this.setScene(scene);
         this.setTitle(applicationName);
         this.show();
-
-        this.setUpEvents();
-    }
-
-    private void setUpEvents() {
-        engines.setUpEvents();
     }
 
     public void showLibrary() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
@@ -4,10 +4,8 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.collections.ObservableList;
 import javafx.scene.control.CheckBox;
-import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.layout.VBox;
-import org.phoenicis.apps.dto.CategoryDTO;
 import org.phoenicis.engines.CombinedEnginesFilter;
 import org.phoenicis.engines.EnginesFilter;
 import org.phoenicis.engines.dto.EngineCategoryDTO;
@@ -35,7 +33,6 @@ public class EngineSideBar extends VBox {
     private Consumer<CombinedEnginesFilter> onApplyFilter = (filter) -> {};
 
     private Consumer<EngineCategoryDTO> onCategorySelection;
-    private Runnable onAllCategorySelection;
 
     public EngineSideBar() {
         this.initializeFilter();
@@ -114,9 +111,5 @@ public class EngineSideBar extends VBox {
 
     public void setOnCategorySelection(Consumer<EngineCategoryDTO> onCategorySelection) {
         this.onCategorySelection = onCategorySelection;
-    }
-
-    public void setOnAllCategorySelection(Runnable onAllCategorySelection) {
-        this.onAllCategorySelection = onAllCategorySelection;
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
@@ -16,38 +16,73 @@ import java.util.function.Consumer;
 import static org.phoenicis.configuration.localisation.Localisation.translate;
 
 /**
- * Created by marc on 22.04.17.
+ * An instance of this class represents the left sidebar of the engines tab view.
+ * This sidebar contains three items:
+ * <ul>
+ * <li>
+ * A searchbar, which enables the user to search for an engine.
+ * </li>
+ * <li>
+ * A button group containing a button for all known engine groups.
+ * After pressing on one such button all engines belonging to the selected engine group are shown in the main window panel.
+ * </li>
+ * <li>
+ * A button group containing buttons to filter for installed and uninstalled engines.
+ * </li>
+ * </ul>
+ *
+ * @author marc
+ * @since 22.04.17
  */
 public class EngineSideBar extends VBox {
+    // the search bar used for filtering
     private SearchBox searchBar;
 
+    // the button group containing a button for all engine categories
     private LeftToggleGroup<EngineCategoryDTO> categoryView;
 
+    // the button group containing a button to filter the engines for installed and uninstalled engines
     private LeftGroup installationFilterGroup;
 
     private CheckBox installedCheck;
     private CheckBox notInstalledCheck;
 
+    // the engines filter
     private CombinedEnginesFilter currentFilter;
 
-    private Consumer<CombinedEnginesFilter> onApplyFilter = (filter) -> {};
+    // consumer called when a filter in the installation filter group has been activated
+    private Consumer<CombinedEnginesFilter> onApplyFilter = filter -> {};
 
+    // consumer called when a category has been selected
     private Consumer<EngineCategoryDTO> onCategorySelection;
 
+    /**
+     * Constructor
+     */
     public EngineSideBar() {
+        super();
+
         this.initializeFilter();
 
         this.populateSearchBar();
-        this.populateEngineTypes();
+        this.populateEngineCategories();
         this.populateInstallationFilters();
 
         this.getChildren().setAll(this.searchBar, new LeftSpacer(), this.categoryView, new LeftSpacer(), this.installationFilterGroup);
     }
 
+    /**
+     * This method takes an {@link ObservableList} of engine categories and binds it to the engrine categories button group
+     *
+     * @param engineCategories The list of engine categories
+     */
     public void bindEngineCategories(ObservableList<EngineCategoryDTO> engineCategories) {
         Bindings.bindContent(categoryView.getElements(), engineCategories);
     }
 
+    /**
+     * This method initializes the engines filter, which is responsible for filtering installed and/or not installed engines
+     */
     private void initializeFilter() {
         this.currentFilter = new CombinedEnginesFilter();
 
@@ -55,15 +90,24 @@ public class EngineSideBar extends VBox {
         this.currentFilter.add(EnginesFilter.NOT_INSTALLED);
     }
 
+    /**
+     * This method populates the searchbar
+     */
     private void populateSearchBar() {
         // TODO: do something when a search term has been entered
         this.searchBar = new SearchBox(filterText -> {}, () -> {});
     }
 
-    private void populateEngineTypes() {
+    /**
+     * This method populates the button group showing all known engine categories
+     */
+    private void populateEngineCategories() {
         this.categoryView = LeftToggleGroup.create(translate("Engines"), this::createCategoryToggleButton);
     }
 
+    /**
+     * This method populates the button group containing buttons to filter for installed and not installed engines
+     */
     private void populateInstallationFilters() {
         this.installedCheck = new LeftCheckBox(translate("Installed"));
         this.installedCheck.setUserData(EnginesFilter.INSTALLED);
@@ -96,6 +140,12 @@ public class EngineSideBar extends VBox {
         this.installationFilterGroup = new LeftGroup(installedCheck, notInstalledCheck);
     }
 
+    /**
+     * This method creates a new toggle button for a given engine category.
+     *
+     * @param category The engine category, for which a new toggle button should be created
+     * @return The created toggle button
+     */
     private ToggleButton createCategoryToggleButton(EngineCategoryDTO category) {
         ToggleButton categoryButton = new LeftToggleButton(category.getName());
 
@@ -105,10 +155,20 @@ public class EngineSideBar extends VBox {
         return categoryButton;
     }
 
+    /**
+     * This method updates the consumer, that is called when the installed or not installed engines filter gets applied
+     *
+     * @param onApplyFilter The new consumer to be called
+     */
     public void setOnApplyFilter(Consumer<CombinedEnginesFilter> onApplyFilter) {
         this.onApplyFilter = onApplyFilter;
     }
 
+    /**
+     * This method updates the consumer, that is called when an engines category gets selected
+     *
+     * @param onCategorySelection The new consumer to be called
+     */
     public void setOnCategorySelection(Consumer<EngineCategoryDTO> onCategorySelection) {
         this.onCategorySelection = onCategorySelection;
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
@@ -64,7 +64,7 @@ public class EngineSideBar extends VBox {
     }
 
     private void populateEngineTypes() {
-        this.categoryView = LeftToggleGroup.create(translate("Engines"), this::createAllCategoriesToggleButton, this::createCategoryToggleButton);
+        this.categoryView = LeftToggleGroup.create(translate("Engines"), this::createCategoryToggleButton);
     }
 
     private void populateInstallationFilters() {
@@ -99,15 +99,6 @@ public class EngineSideBar extends VBox {
         this.installationFilterGroup = new LeftGroup(installedCheck, notInstalledCheck);
     }
 
-    private ToggleButton createAllCategoriesToggleButton() {
-        ToggleButton categoryButton = new LeftToggleButton("All");
-
-        categoryButton.setId("allButton");
-        categoryButton.setOnMouseClicked(event -> onAllCategorySelection.run());
-
-        return categoryButton;
-    }
-
     private ToggleButton createCategoryToggleButton(EngineCategoryDTO category) {
         ToggleButton categoryButton = new LeftToggleButton(category.getName());
 
@@ -115,5 +106,17 @@ public class EngineSideBar extends VBox {
         categoryButton.setOnMouseClicked(event -> onCategorySelection.accept(category));
 
         return categoryButton;
+    }
+
+    public void setOnApplyFilter(Consumer<CombinedEnginesFilter> onApplyFilter) {
+        this.onApplyFilter = onApplyFilter;
+    }
+
+    public void setOnCategorySelection(Consumer<EngineCategoryDTO> onCategorySelection) {
+        this.onCategorySelection = onCategorySelection;
+    }
+
+    public void setOnAllCategorySelection(Runnable onAllCategorySelection) {
+        this.onAllCategorySelection = onAllCategorySelection;
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
@@ -1,0 +1,119 @@
+package org.phoenicis.javafx.views.mainwindow.engines;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.BooleanProperty;
+import javafx.collections.ObservableList;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Toggle;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.VBox;
+import org.phoenicis.apps.dto.CategoryDTO;
+import org.phoenicis.engines.CombinedEnginesFilter;
+import org.phoenicis.engines.EnginesFilter;
+import org.phoenicis.engines.dto.EngineCategoryDTO;
+import org.phoenicis.javafx.views.mainwindow.ui.*;
+
+import java.util.function.Consumer;
+
+import static org.phoenicis.configuration.localisation.Localisation.translate;
+
+/**
+ * Created by marc on 22.04.17.
+ */
+public class EngineSideBar extends VBox {
+    private SearchBox searchBar;
+
+    private LeftToggleGroup<EngineCategoryDTO> categoryView;
+
+    private LeftGroup installationFilterGroup;
+
+    private CheckBox installedCheck;
+    private CheckBox notInstalledCheck;
+
+    private CombinedEnginesFilter currentFilter;
+
+    private Consumer<CombinedEnginesFilter> onApplyFilter = (filter) -> {};
+
+    private Consumer<EngineCategoryDTO> onCategorySelection;
+    private Runnable onAllCategorySelection;
+
+    public EngineSideBar() {
+        this.initializeFilter();
+
+        this.populateSearchBar();
+        this.populateEngineTypes();
+        this.populateInstallationFilters();
+
+        this.getChildren().setAll(this.searchBar, new LeftSpacer(), this.categoryView, new LeftSpacer(), this.installationFilterGroup);
+    }
+
+    public void bindEngineCategories(ObservableList<EngineCategoryDTO> engineCategories) {
+        Bindings.bindContent(categoryView.getElements(), engineCategories);
+    }
+
+    private void initializeFilter() {
+        this.currentFilter = new CombinedEnginesFilter();
+
+        this.currentFilter.add(EnginesFilter.INSTALLED);
+        this.currentFilter.add(EnginesFilter.NOT_INSTALLED);
+    }
+
+    private void populateSearchBar() {
+        // TODO: do something when a search term has been entered
+        this.searchBar = new SearchBox(filterText -> {}, () -> {});
+    }
+
+    private void populateEngineTypes() {
+        this.categoryView = LeftToggleGroup.create(translate("Engines"), this::createAllCategoriesToggleButton, this::createCategoryToggleButton);
+    }
+
+    private void populateInstallationFilters() {
+        this.installedCheck = new LeftCheckBox(translate("Installed"));
+        this.installedCheck.setUserData(EnginesFilter.INSTALLED);
+        this.installedCheck.setSelected(true);
+        this.installedCheck.selectedProperty().addListener((observableValue, oldValue, newValue) -> {
+            BooleanProperty selectedProperty = (BooleanProperty) observableValue;
+            CheckBox checkBox = (CheckBox) selectedProperty.getBean();
+            if (newValue) {
+                currentFilter.add((EnginesFilter) checkBox.getUserData());
+            } else {
+                currentFilter.remove((EnginesFilter) checkBox.getUserData());
+            }
+            onApplyFilter.accept(currentFilter);
+        });
+
+        this.notInstalledCheck = new LeftCheckBox(translate("Not installed"));
+        this.notInstalledCheck.setUserData(EnginesFilter.NOT_INSTALLED);
+        this.notInstalledCheck.setSelected(true);
+        this.notInstalledCheck.selectedProperty().addListener((observableValue, oldValue, newValue) -> {
+            BooleanProperty selectedProperty = (BooleanProperty) observableValue;
+            CheckBox checkBox = (CheckBox) selectedProperty.getBean();
+            if (newValue) {
+                currentFilter.add((EnginesFilter) checkBox.getUserData());
+            } else {
+                currentFilter.remove((EnginesFilter) checkBox.getUserData());
+            }
+            onApplyFilter.accept(currentFilter);
+        });
+
+        this.installationFilterGroup = new LeftGroup(installedCheck, notInstalledCheck);
+    }
+
+    private ToggleButton createAllCategoriesToggleButton() {
+        ToggleButton categoryButton = new LeftToggleButton("All");
+
+        categoryButton.setId("allButton");
+        categoryButton.setOnMouseClicked(event -> onAllCategorySelection.run());
+
+        return categoryButton;
+    }
+
+    private ToggleButton createCategoryToggleButton(EngineCategoryDTO category) {
+        ToggleButton categoryButton = new LeftToggleButton(category.getName());
+
+        categoryButton.setId(String.format("%sButton", category.getName().toLowerCase()));
+        categoryButton.setOnMouseClicked(event -> onCategorySelection.accept(category));
+
+        return categoryButton;
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/ViewEngines.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/ViewEngines.java
@@ -59,7 +59,6 @@ public class ViewEngines extends MainWindowView {
 
         this.engineCategories = FXCollections.observableArrayList();
 
-        this.sideBar.setOnAllCategorySelection(this::showAvailableEngines);
         this.sideBar.setOnCategorySelection(this::selectCategory);
 
         this.sideBar.bindEngineCategories(engineCategories);

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleGroup.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleGroup.java
@@ -4,11 +4,14 @@ import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
+import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.VBox;
 import org.phoenicis.javafx.views.common.MappedList;
 
+import javax.swing.text.html.Option;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -17,15 +20,43 @@ import java.util.function.Supplier;
  */
 public class LeftToggleGroup<E> extends LeftGroup {
     private final ToggleGroup toggleGroup;
-    private final ToggleButton allButton;
+    private final Optional<ToggleButton> allButton;
 
     private final VBox toggleButtonBox;
 
     private final ObservableList<E> elements;
     private final ObservableList<? extends ToggleButton> mappedToggleButtons;
 
+    public static <T> LeftToggleGroup<T> create(String name, Function<T, ? extends ToggleButton> converter) {
+        return new LeftToggleGroup<T>(name, converter);
+    }
+
     public static <T> LeftToggleGroup<T> create(String name, Supplier<ToggleButton> allButtonSupplier, Function<T, ? extends ToggleButton> converter) {
         return new LeftToggleGroup<T>(name, allButtonSupplier, converter);
+    }
+
+    private LeftToggleGroup(String name, Function<E, ? extends ToggleButton> converter) {
+        super(name);
+
+        this.toggleGroup = new ToggleGroup();
+        this.toggleButtonBox = new VBox();
+        this.toggleButtonBox.getStyleClass().add("leftPaneInside");
+
+        this.elements = FXCollections.observableArrayList();
+        this.mappedToggleButtons = new MappedList<ToggleButton, E>(this.elements, value -> {
+            ToggleButton button = converter.apply(value);
+
+            button.setToggleGroup(toggleGroup);
+
+            return button;
+        });
+
+        this.allButton = Optional.empty();
+
+        ObservableList<Node> target = this.getChildren();
+        target.add(toggleButtonBox);
+
+        Bindings.bindContent(this.toggleButtonBox.getChildren(), this.mappedToggleButtons);
     }
 
     private LeftToggleGroup(String name, Supplier<ToggleButton> allButtonSupplier, Function<E, ? extends ToggleButton> converter) {
@@ -44,11 +75,13 @@ public class LeftToggleGroup<E> extends LeftGroup {
             return button;
         });
 
-        this.allButton = allButtonSupplier.get();
-        this.allButton.setToggleGroup(toggleGroup);
+        ToggleButton createdAllButton = allButtonSupplier.get();
+        createdAllButton.setToggleGroup(toggleGroup);
+
+        this.allButton = Optional.of(createdAllButton);
 
         ObservableList<Node> target = this.getChildren();
-        target.add(allButton);
+        target.add(createdAllButton);
         target.add(toggleButtonBox);
 
         Bindings.bindContent(this.toggleButtonBox.getChildren(), this.mappedToggleButtons);
@@ -59,6 +92,6 @@ public class LeftToggleGroup<E> extends LeftGroup {
     }
 
     public void selectAll() {
-        this.allButton.setSelected(true);
+        this.allButton.ifPresent(button -> button.setSelected(true));
     }
 }


### PR DESCRIPTION
This PR moves the sidebar code from the `EnginesView` to its own class `EngineSideBar`.
In addition it introduces the `LeftToggleGroup` class in the engines sidebar to show the different engine categories.