### PR TITLE
Refactoring the "Settings" tab

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/settings/SettingsController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/settings/SettingsController.java
@@ -29,8 +29,6 @@ public class SettingsController {
                               SettingsManager settingsManager) {
         this.view = view;
         this.settingsManager = settingsManager;
-        this.view.setOnSave(settingsManager::save);
-        this.view.setSettings();
     }
 
     public ViewSettings getView() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/AboutPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/AboutPanel.java
@@ -1,0 +1,125 @@
+package org.phoenicis.javafx.views.mainwindow.settings;
+
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import org.phoenicis.javafx.views.common.TextWithStyle;
+import org.phoenicis.tools.system.opener.Opener;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.phoenicis.configuration.localisation.Localisation.translate;
+
+/**
+ * This class represents the "About" settings category
+ *
+ * @author marc
+ * @since 23.04.17
+ */
+public class AboutPanel extends VBox {
+    private ApplicationBuildInformation buildInformation;
+    private Opener opener;
+
+    private Text title;
+
+    private GridPane aboutGrid;
+
+    private Text nameDescription;
+    private Label nameLabel;
+
+    private Text versionDescription;
+    private Label versionLabel;
+
+    private Text gitRevisionDescription;
+    private Hyperlink gitRevisionHyperlink;
+
+    private Text buildTimestampDescription;
+    private Label buildTimestampLabel;
+
+    public AboutPanel(ApplicationBuildInformation buildInformation, Opener opener) {
+        super();
+
+        this.buildInformation = buildInformation;
+        this.opener = opener;
+
+        this.getStyleClass().add("containerConfigurationPane");
+
+        this.populate();
+
+        this.getChildren().setAll(title, aboutGrid);
+    }
+
+    private void populate() {
+        this.title = new TextWithStyle(translate("About"), "title");
+
+        this.aboutGrid = new GridPane();
+        this.aboutGrid.getStyleClass().add("grid");
+        this.aboutGrid.setHgap(20);
+        this.aboutGrid.setVgap(10);
+
+        this.nameDescription = new TextWithStyle(translate("Name:"), "captionTitle");
+        this.nameLabel = new Label(buildInformation.getApplicationName());
+
+        this.versionDescription = new TextWithStyle(translate("Version:"), "captionTitle");
+        this.versionLabel = new Label(buildInformation.getApplicationVersion());
+
+        this.gitRevisionDescription = new TextWithStyle(translate("Git Revision:"), "captionTitle");
+        this.gitRevisionHyperlink = new Hyperlink(buildInformation.getApplicationGitRevision());
+        this.gitRevisionHyperlink.setOnAction(event -> {
+            try {
+                URI uri = new URI("https://github.com/PlayOnLinux/POL-POM-5/commit/" + buildInformation.getApplicationGitRevision());
+                opener.open(uri);
+            } catch (URISyntaxException e) {
+                e.printStackTrace();
+            }
+        });
+
+        this.buildTimestampDescription = new TextWithStyle(translate("Build Timestamp:"), "captionTitle");
+        this.buildTimestampLabel = new Label(buildInformation.getApplicationBuildTimestamp());
+
+        this.aboutGrid.add(nameDescription, 0, 0);
+        this.aboutGrid.add(nameLabel, 1, 0);
+
+        this.aboutGrid.add(versionDescription, 0, 1);
+        this.aboutGrid.add(versionLabel, 1, 1);
+
+        this.aboutGrid.add(gitRevisionDescription, 0, 2);
+        this.aboutGrid.add(gitRevisionHyperlink, 1, 2);
+
+        this.aboutGrid.add(buildTimestampDescription, 0, 3);
+        this.aboutGrid.add(buildTimestampLabel, 1, 3);
+    }
+
+    public static class ApplicationBuildInformation {
+        private String applicationName;
+        private String applicationVersion;
+        private String applicationGitRevision;
+        private String applicationBuildTimestamp;
+
+        public ApplicationBuildInformation(String applicationName, String applicationVersion, String applicationGitRevision, String applicationBuildTimestamp) {
+            this.applicationName = applicationName;
+            this.applicationVersion = applicationVersion;
+            this.applicationGitRevision = applicationGitRevision;
+            this.applicationBuildTimestamp = applicationBuildTimestamp;
+        }
+
+        public String getApplicationName() {
+            return applicationName;
+        }
+
+        public String getApplicationVersion() {
+            return applicationVersion;
+        }
+
+        public String getApplicationGitRevision() {
+            return applicationGitRevision;
+        }
+
+        public String getApplicationBuildTimestamp() {
+            return applicationBuildTimestamp;
+        }
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/AboutPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/AboutPanel.java
@@ -39,6 +39,12 @@ public class AboutPanel extends VBox {
     private Text buildTimestampDescription;
     private Label buildTimestampLabel;
 
+    /**
+     * Constructor
+     *
+     * @param buildInformation The information of the used build of POL 5
+     * @param opener           The opener util object to be used to open websites
+     */
     public AboutPanel(ApplicationBuildInformation buildInformation, Opener opener) {
         super();
 
@@ -93,12 +99,27 @@ public class AboutPanel extends VBox {
         this.aboutGrid.add(buildTimestampLabel, 1, 3);
     }
 
+    /**
+     * This class contains information about the POL 5 build
+     */
     public static class ApplicationBuildInformation {
+        // the name of the application
         private String applicationName;
+        // the version of the application (taken from the maven pom file)
         private String applicationVersion;
+        // the git revision/commit used to build POL 5
         private String applicationGitRevision;
+        // the timestamp when POL 5 was built
         private String applicationBuildTimestamp;
 
+        /**
+         * Constructor
+         *
+         * @param applicationName           the name of the application
+         * @param applicationVersion        the version of the application
+         * @param applicationGitRevision    the git revision/commit used to build POL 5
+         * @param applicationBuildTimestamp the timestamp when POL 5 was built
+         */
         public ApplicationBuildInformation(String applicationName, String applicationVersion, String applicationGitRevision, String applicationBuildTimestamp) {
             this.applicationName = applicationName;
             this.applicationVersion = applicationVersion;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/FileAssociationsPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/FileAssociationsPanel.java
@@ -1,0 +1,15 @@
+package org.phoenicis.javafx.views.mainwindow.settings;
+
+import javafx.scene.layout.VBox;
+
+/**
+ * This class represents the "File Associations" settings category
+ *
+ * @author marc
+ * @since 23.04.17
+ */
+public class FileAssociationsPanel extends VBox {
+    public FileAssociationsPanel() {
+        super();
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/NetworkPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/NetworkPanel.java
@@ -1,0 +1,15 @@
+package org.phoenicis.javafx.views.mainwindow.settings;
+
+import javafx.scene.layout.VBox;
+
+/**
+ * This class represents the "Network" settings category
+ *
+ * @author marc
+ * @since 23.04.17
+ */
+public class NetworkPanel extends VBox {
+    public NetworkPanel() {
+        super();
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/RepositoriesPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/RepositoriesPanel.java
@@ -1,0 +1,191 @@
+package org.phoenicis.javafx.views.mainwindow.settings;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.event.ActionEvent;
+import javafx.geometry.Insets;
+import javafx.geometry.VPos;
+import javafx.scene.control.*;
+import javafx.scene.layout.*;
+import javafx.scene.text.Text;
+import org.phoenicis.apps.RepositoryManager;
+import org.phoenicis.javafx.views.common.TextWithStyle;
+import org.phoenicis.settings.SettingsManager;
+
+import java.util.Optional;
+
+import static org.phoenicis.configuration.localisation.Localisation.translate;
+
+/**
+ * This class represents the "Repositories" settings category
+ *
+ * @author marc
+ * @since 23.04.17
+ */
+public class RepositoriesPanel extends VBox {
+    private SettingsManager settingsManager;
+    private RepositoryManager repositoryManager;
+
+    private Text title;
+
+    private GridPane repositoryGrid;
+
+    private Text repositoryText;
+    private VBox repositoryLayout;
+    private ListView<String> repositoryListView;
+    private HBox repositoryButtonLayout;
+    private Button addButton;
+    private Button removeButton;
+
+    private Label priorityHint;
+
+    private GridPane refreshLayout;
+
+    private Label refreshRepositoriesLabel;
+    private Button refreshRepositoriesButton;
+
+    private ObservableList<String> repositories;
+
+    /**
+     * Constructor
+     *
+     * @param settingsManager The settings manager
+     * @param repositoryManager The repository manager
+     */
+    public RepositoriesPanel(SettingsManager settingsManager, RepositoryManager repositoryManager) {
+        super();
+
+        this.settingsManager = settingsManager;
+        this.repositoryManager = repositoryManager;
+        this.repositories = FXCollections.observableArrayList(settingsManager.getRepository().split(";"));
+
+        this.getStyleClass().add("containerConfigurationPane");
+
+        this.populateRepositoryGrid();
+        this.populateRepositoryLegend();
+        this.populateRepositoryRefresh();
+
+        this.initializeRefreshCallback();
+
+        this.getChildren().setAll(title, repositoryGrid, priorityHint, refreshLayout);
+    }
+
+    private void initializeRefreshCallback() {
+        repositoryManager.addCallbacks(categories -> {
+            Platform.runLater(() -> {
+                refreshRepositoriesButton.getStyleClass().remove("refreshIcon");
+                refreshRepositoriesButton.setDisable(false);
+            });
+        }, error -> {
+        });
+    }
+
+    private void populateRepositoryGrid() {
+        this.title = new TextWithStyle(translate("Repositories Settings"), "title");
+
+        this.repositoryGrid = new GridPane();
+        this.repositoryGrid.getStyleClass().add("grid");
+        this.repositoryGrid.setHgap(20);
+        this.repositoryGrid.setVgap(10);
+
+        this.repositoryText = new TextWithStyle(translate("Repository:"), "captionTitle");
+
+        this.repositoryLayout = new VBox();
+        this.repositoryLayout.setSpacing(5);
+
+        this.repositoryListView = new ListView<>(repositories);
+        this.repositoryListView.setPrefSize(400, 100);
+        this.repositoryListView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+        this.repositoryListView.setEditable(true);
+        this.repositoryListView.setCellFactory(param -> new DragableRepositoryListCell((repositoryUrl, toIndex) -> {
+            this.repositoryManager.moveRepository(repositoryUrl, toIndex.intValue());
+
+            this.save();
+        }));
+
+        this.repositoryButtonLayout = new HBox();
+        this.repositoryButtonLayout.setSpacing(5);
+
+        this.addButton = new Button();
+        this.addButton.setText("Add");
+        this.addButton.setOnAction((ActionEvent event) -> {
+            TextInputDialog dialog = new TextInputDialog();
+            dialog.initOwner(getScene().getWindow());
+            dialog.setTitle("Add repository");
+            dialog.setHeaderText("Add repository");
+            dialog.setContentText("Please add the new repository:");
+
+            Optional<String> result = dialog.showAndWait();
+            result.ifPresent(newRepository -> {
+                repositories.add(0, newRepository);
+
+                this.save();
+
+                repositoryManager.addRepositories(0, newRepository);
+            });
+        });
+
+        this.removeButton = new Button();
+        this.removeButton.setText("Remove");
+        this.removeButton.setOnAction((ActionEvent event) -> {
+            String[] toRemove = repositoryListView.getSelectionModel().getSelectedItems().toArray(new String[0]);
+
+            repositories.removeAll(toRemove);
+
+            this.save();
+
+            repositoryManager.removeRepositories(toRemove);
+        });
+
+        this.repositoryButtonLayout.getChildren().addAll(addButton, removeButton);
+
+        this.repositoryLayout.getChildren().addAll(repositoryListView, repositoryButtonLayout);
+
+        this.repositoryGrid.add(repositoryText, 0, 0);
+        this.repositoryGrid.add(repositoryLayout, 1, 0);
+
+        GridPane.setValignment(repositoryText, VPos.TOP);
+    }
+
+    private void populateRepositoryLegend() {
+        this.priorityHint = new Label(translate("The value in front of each repository is its priority. The higher the priority is, the more important the scripts inside the repository are."));
+        this.priorityHint.setWrapText(true);
+        this.priorityHint.setPadding(new Insets(10));
+    }
+
+    private void populateRepositoryRefresh() {
+        // Refresh Repositories
+        this.refreshLayout = new GridPane();
+        this.refreshLayout.setHgap(20);
+        this.refreshLayout.setVgap(10);
+
+        ColumnConstraints columnConstraints = new ColumnConstraints();
+        columnConstraints.setFillWidth(true);
+        columnConstraints.setHgrow(Priority.ALWAYS);
+        this.refreshLayout.getColumnConstraints().add(columnConstraints);
+
+        this.refreshRepositoriesLabel = new Label(translate("Fetch updates for the repositories to retrieve the newest script versions"));
+        this.refreshRepositoriesLabel.setWrapText(true);
+
+        this.refreshRepositoriesButton = new Button("Refresh Repositories");
+        this.refreshRepositoriesButton.setOnAction(event -> {
+            refreshRepositoriesButton.getStyleClass().add("refreshIcon");
+            refreshRepositoriesButton.setDisable(true);
+            repositoryManager.triggerRepositoryChange();
+        });
+
+        this.refreshLayout.add(refreshRepositoriesLabel, 0, 0);
+        this.refreshLayout.add(refreshRepositoriesButton, 1, 0);
+    }
+
+    private void save() {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (String repository : repositories) {
+            stringBuilder.append(repository).append(";");
+        }
+        settingsManager.setRepository(stringBuilder.toString());
+
+        settingsManager.save();
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/SettingsSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/SettingsSideBar.java
@@ -66,6 +66,13 @@ public class SettingsSideBar extends VBox {
     }
 
     /**
+     * This method selects the first settings category
+     */
+    public void selectFirstSettingsCategory() {
+        this.settingsItems.select(0);
+    }
+
+    /**
      * This method updates the consumer that is called when a settings toggle button has been clicked
      *
      * @param onSelectSettingsItem The new consumer to be called

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/SettingsSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/SettingsSideBar.java
@@ -1,0 +1,113 @@
+package org.phoenicis.javafx.views.mainwindow.settings;
+
+import javafx.beans.binding.Bindings;
+import javafx.collections.ObservableList;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.VBox;
+import org.phoenicis.javafx.views.mainwindow.ui.LeftToggleButton;
+import org.phoenicis.javafx.views.mainwindow.ui.LeftToggleGroup;
+
+import java.util.function.Consumer;
+
+/**
+ * An instance of this class represents the sidebar inside the settings tab view.
+ * This sidebar contains a toggle button group used to select the different types of settings.
+ *
+ * @author marc
+ * @since 23.04.17
+ */
+public class SettingsSideBar extends VBox {
+    // the toggle button group containing the buttons used to navigate to the different setting panels
+    private LeftToggleGroup<SettingsSideBarItem> settingsItems;
+
+    // consumer called when a settings toggle button has been clicked
+    private Consumer<VBox> onSelectSettingsItem;
+
+    /**
+     * Constructor
+     */
+    public SettingsSideBar() {
+        super();
+
+        this.populate();
+
+        this.getChildren().addAll(this.settingsItems);
+    }
+
+    /**
+     * This method populates the toggle button group containing a toggle button for each settings panel
+     */
+    private void populate() {
+        this.settingsItems = LeftToggleGroup.create("Settings", this::createSettingsToggleButton);
+    }
+
+    /**
+     * This method creates a toggle button for a given settings panel.
+     *
+     * @param item The settings panel together with its displayed name and icon css class
+     * @return The created toggle button
+     */
+    private ToggleButton createSettingsToggleButton(SettingsSideBarItem item) {
+        ToggleButton toggleButton = new LeftToggleButton(item.getName());
+
+        toggleButton.getStyleClass().add(item.getIconClass());
+        toggleButton.setOnAction(event -> onSelectSettingsItem.accept(item.getPanel()));
+
+        return toggleButton;
+    }
+
+    /**
+     * This method binds the given settings panels to the toggle button group inside this sidebar
+     *
+     * @param items The settings toggle buttons
+     */
+    public void bindSettingsItems(ObservableList<SettingsSideBarItem> items) {
+        Bindings.bindContent(this.settingsItems.getElements(), items);
+    }
+
+    /**
+     * This method updates the consumer that is called when a settings toggle button has been clicked
+     *
+     * @param onSelectSettingsItem The new consumer to be called
+     */
+    public void setOnSelectSettingsItem(Consumer<VBox> onSelectSettingsItem) {
+        this.onSelectSettingsItem = onSelectSettingsItem;
+    }
+
+    /**
+     * This class contains all needed information to display and manage a settings panel
+     */
+    public static class SettingsSideBarItem {
+        // the corresponding panel for this settings category
+        private final VBox panel;
+        // the css class containing the icon for this settings category
+        private final String iconClass;
+        // the displayed name of this settings category
+        private final String name;
+
+        /**
+         * Constructor
+         *
+         * @param panel     The corresponding panel for this settings category
+         * @param iconClass The css class containing the icon for this settings category
+         * @param name      The displayed name of this settings category
+         */
+        public SettingsSideBarItem(VBox panel, String iconClass, String name) {
+            this.panel = panel;
+            this.iconClass = iconClass;
+            this.name = name;
+        }
+
+        public VBox getPanel() {
+            return panel;
+        }
+
+        public String getIconClass() {
+            return iconClass;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/UserInterfacePanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/UserInterfacePanel.java
@@ -1,0 +1,106 @@
+package org.phoenicis.javafx.views.mainwindow.settings;
+
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import org.phoenicis.javafx.views.common.TextWithStyle;
+import org.phoenicis.javafx.views.common.Theme;
+import org.phoenicis.javafx.views.common.ThemeManager;
+import org.phoenicis.settings.SettingsManager;
+
+import java.net.URL;
+
+import static org.phoenicis.configuration.localisation.Localisation.translate;
+
+/**
+ * This class represents the "User Interface" settings category
+ *
+ * @author marc
+ * @since 23.04.17
+ */
+public class UserInterfacePanel extends VBox {
+    private SettingsManager settingsManager;
+    private ThemeManager themeManager;
+
+    private Text title;
+
+    private GridPane themeGrid;
+
+    private Text themeTitle;
+    private ComboBox<Theme> themes;
+
+    private Label showScriptDescription;
+    private CheckBox showScriptSource;
+
+    /**
+     * Constructor
+     *
+     * @param settingsManager The settings manager
+     * @param themeManager The theme manager
+     */
+    public UserInterfacePanel(SettingsManager settingsManager, ThemeManager themeManager) {
+        super();
+
+        this.settingsManager = settingsManager;
+        this.themeManager = themeManager;
+
+        this.getStyleClass().add("containerConfigurationPane");
+
+        this.populate();
+
+        this.getChildren().setAll(title, themeGrid);
+    }
+
+    private void populate() {
+        this.title = new TextWithStyle(translate("User Interface Settings"), "title");
+
+        this.themeGrid = new GridPane();
+        this.themeGrid.getStyleClass().add("grid");
+        this.themeGrid.setHgap(20);
+        this.themeGrid.setVgap(10);
+
+        // Change Theme
+        this.themeTitle = new TextWithStyle(translate("Theme:"), "captionTitle");
+
+        this.themes = new ComboBox<>();
+        this.themes.getItems().setAll(Theme.values());
+        this.themes.setValue(Theme.fromShortName(settingsManager.getTheme()));
+        this.themes.setOnAction(event -> {
+            this.handleThemeChange();
+            this.save();
+        });
+
+        // View Script Sources
+        this.showScriptSource = new CheckBox();
+        this.showScriptSource.setSelected(settingsManager.isViewScriptSource());
+        this.showScriptSource.setOnAction(event -> this.save());
+
+        this.showScriptDescription = new Label(translate("Select, if you want to view the source repository of the scripts"));
+
+        this.themeGrid.add(themeTitle, 0, 0);
+        this.themeGrid.add(themes, 1, 0);
+        this.themeGrid.add(showScriptSource, 0, 1);
+        this.themeGrid.add(showScriptDescription, 1, 1);
+    }
+
+    private void handleThemeChange() {
+        final Theme theme = themes.getSelectionModel().getSelectedItem();
+        themeManager.setCurrentTheme(theme);
+        final String shortName = theme.getShortName();
+        final String url = String.format("/org/phoenicis/javafx/themes/%s/main.css", shortName);
+        final URL style = this.getClass().getResource(url);
+
+        getScene().getStylesheets()
+                .setAll(themeManager.getDefaultCategoryIconsCss(), themeManager.getDefaultEngineIconsCss(), style.toExternalForm());
+    }
+
+    private void save() {
+        settingsManager.setTheme(themes.getSelectionModel().getSelectedItem().getShortName());
+        settingsManager.setViewScriptSource(showScriptSource.isSelected());
+
+        settingsManager.save();
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
@@ -27,8 +27,6 @@ import org.phoenicis.javafx.views.mainwindow.MessagePanel;
 import org.phoenicis.settings.SettingsManager;
 import org.phoenicis.tools.system.opener.Opener;
 
-import static org.phoenicis.configuration.localisation.Localisation.translate;
-
 public class ViewSettings extends MainWindowView {
     private final String applicationName;
     private final String applicationVersion;
@@ -68,8 +66,7 @@ public class ViewSettings extends MainWindowView {
         addToSideBar(sideBar);
         super.drawSideBar();
 
-        initSelectSettingsPane();
-        showRightView(this.selectSettingsPanel);
+        this.sideBar.selectFirstSettingsCategory();
     }
 
     private void initializeSettingsItems() {
@@ -82,9 +79,5 @@ public class ViewSettings extends MainWindowView {
                 new SettingsSideBar.SettingsSideBarItem(new FileAssociationsPanel(), "settingsButton", "File Associations"),
                 new SettingsSideBar.SettingsSideBarItem(new NetworkPanel(), "networkButton", "Network"),
                 new SettingsSideBar.SettingsSideBarItem(new AboutPanel(buildInformation, opener), "aboutButton", "About"));
-    }
-
-    private void initSelectSettingsPane() {
-        this.selectSettingsPanel = new MessagePanel(translate("Please select a settings category"));
     }
 }

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.css
@@ -644,6 +644,11 @@
 /************************ icons ************************/
 /*******************************************************/
 
+/************************ util *************************/
+.refreshIcon {
+    -fx-graphic: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/refresh.png');
+}
+
 /************************ apps *************************/
 #allButton {
     -fx-background-image: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/apps/all.png');

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/dark/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/dark/main.css
@@ -417,6 +417,11 @@
 /*******************************************************/
 /************************ icons ************************/
 /*******************************************************/
+/************************ util *************************/
+.refreshIcon {
+    -fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/refresh.png');
+}
+
 /************************ apps *************************/
 #allButton {
     -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/apps/all.png');

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.css
@@ -421,6 +421,11 @@
 /*******************************************************/
 /************************ icons ************************/
 /*******************************************************/
+/************************ util *************************/
+.refreshIcon {
+    -fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/refresh.png');
+}
+
 /************************ apps *************************/
 #allButton {
     -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/apps/all.png');

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/hidpi/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/hidpi/main.css
@@ -411,6 +411,11 @@
 /*******************************************************/
 /************************ icons ************************/
 /*******************************************************/
+/************************ util *************************/
+.refreshIcon {
+    -fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/refresh.png');
+}
+
 /************************ apps *************************/
 #allButton {
     -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/apps/all.png');

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.css
@@ -688,6 +688,11 @@
 /*******************************************************/
 /************************ icons ************************/
 /*******************************************************/
+/************************ util *************************/
+.refreshIcon {
+    -fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/refresh.png');
+}
+
 /************************ apps *************************/
 #allButton {
     -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/apps/all.png');


### PR DESCRIPTION
This PR refactors the "Settings" tab. This includes moving some functionality to new classes.

In this PR I've also tried to use `-fx-background-image` for the refresh icon in the "Refresh Repositories" button. The problem is that it didn't want to work, which is the reason why I'm still using `-fx-graphic`.
It would be nice if someone else could change `-fx-graphic` with `-fx-background-image`, because it seems like I don't get it working with `-fx-background-image`.