### PR TITLE
Refactored and improving the LeftToggleGroup

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/AdhocList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/AdhocList.java
@@ -7,11 +7,24 @@ import javafx.collections.transformation.TransformationList;
 import java.util.stream.IntStream;
 
 /**
- * Created by marc on 26.04.17.
+ * This class combines an {@link ObservableList} and a number of non exchangeable objects called <code>others</code> to a single {@link ObservableList}.
+ * These <code>others</code> are prepended to the given {@link ObservableList}.
+ *
+ * @author marc
+ * @since 26.04.17
  */
 public class AdhocList<E> extends TransformationList<E, E> {
+    /**
+     * An array containing a number of objects that are prepended to the {@link ObservableList} <code>source</code>
+     */
     private E[] others;
 
+    /**
+     * Constructor
+     *
+     * @param source An observable list which should be part of this list
+     * @param others A number of objects of the same type as <code>source</code> that should be prepended to <code>source</code>
+     */
     public AdhocList(ObservableList<? extends E> source, E... others) {
         super(source);
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/AdhocList.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/AdhocList.java
@@ -1,0 +1,88 @@
+package org.phoenicis.javafx.views.common;
+
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.TransformationList;
+
+import java.util.stream.IntStream;
+
+/**
+ * Created by marc on 26.04.17.
+ */
+public class AdhocList<E> extends TransformationList<E, E> {
+    private E[] others;
+
+    public AdhocList(ObservableList<? extends E> source, E... others) {
+        super(source);
+
+        this.others = others;
+    }
+
+    @Override
+    public int getSourceIndex(int index) {
+        return index - others.length;
+    }
+
+    @Override
+    public E get(int index) {
+        if (index < others.length) {
+            return others[index];
+        } else {
+            return getSource().get(index - others.length);
+        }
+    }
+
+    @Override
+    public int size() {
+        return others.length + getSource().size();
+    }
+
+    @Override
+    protected void sourceChanged(ListChangeListener.Change<? extends E> c) {
+        beginChange();
+        while (c.next()) {
+            if (c.wasPermutated()) {
+                permutate(c);
+            } else if (c.wasUpdated()) {
+                update(c);
+            } else {
+                addRemove(c);
+            }
+        }
+        endChange();
+    }
+
+    private void permutate(ListChangeListener.Change<? extends E> c) {
+        int from = c.getFrom();
+        int to = c.getTo();
+
+        if (to > from) {
+            int[] perm = IntStream.range(0, size()).toArray();
+
+            for (int i = from; i < to; ++i) {
+                perm[i + others.length] = c.getPermutation(i) + others.length;
+            }
+
+            nextPermutation(from, to, perm);
+        }
+    }
+
+    private void update(ListChangeListener.Change<? extends E> c) {
+        int from = c.getFrom();
+        int to = c.getTo();
+
+        if (to > from) {
+            for (int i = from; i < to; ++i) {
+                nextUpdate(i + others.length);
+            }
+        }
+    }
+
+    private void addRemove(ListChangeListener.Change<? extends E> c) {
+        int from = c.getFrom();
+        int to = c.getTo();
+
+        nextRemove(from + others.length, c.getRemoved());
+        nextAdd(from + others.length, from + c.getAddedSize() + others.length);
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleButton.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleButton.java
@@ -22,7 +22,13 @@ import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.ToggleButton;
 
+/**
+ * This class represents a toggle button in the sidebar.
+ */
 public class LeftToggleButton extends ToggleButton {
+    /**
+     * The text shown in the button
+     */
     private final String name;
 
     public LeftToggleButton(String name) {
@@ -32,6 +38,17 @@ public class LeftToggleButton extends ToggleButton {
         this.setPrefWidth(Double.MAX_VALUE);
         this.setAlignment(Pos.CENTER_LEFT);
         this.setPadding(new Insets(2));
+    }
+
+    @Override
+    public void fire() {
+        /**
+         * Taken from:
+         * https://bitbucket.org/controlsfx/controlsfx/issues/84/segmented-button-control-clicking-on
+         */
+        if (getToggleGroup() == null || !isSelected()) {
+            super.fire();
+        }
     }
 
     public String getName() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleButton.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleButton.java
@@ -31,6 +31,11 @@ public class LeftToggleButton extends ToggleButton {
      */
     private final String name;
 
+    /**
+     * Constructor
+     *
+     * @param name The text to be shown in this toggle button
+     */
     public LeftToggleButton(String name) {
         super(name);
         this.name = name;
@@ -40,6 +45,13 @@ public class LeftToggleButton extends ToggleButton {
         this.setPadding(new Insets(2));
     }
 
+    /**
+     * This method is called whenever the {@link LeftToggleButton} has been clicked.
+     * It is overriden to ensure that the button only fires an event ({@link javafx.event.ActionEvent} or {@link javafx.scene.input.MouseEvent})
+     * if it is either currently not selected or it isn't part of a {@link javafx.scene.control.ToggleGroup}.
+     *
+     * @see ToggleButton
+     */
     @Override
     public void fire() {
         /**
@@ -51,6 +63,11 @@ public class LeftToggleButton extends ToggleButton {
         }
     }
 
+    /**
+     * This method returns the shown text of this button.
+     *
+     * @return The currently shown text of this button.
+     */
     public String getName() {
         return name;
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleGroup.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleGroup.java
@@ -3,40 +3,65 @@ package org.phoenicis.javafx.views.mainwindow.ui;
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.scene.Node;
-import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.VBox;
 import org.phoenicis.javafx.views.common.AdhocList;
 import org.phoenicis.javafx.views.common.MappedList;
 
-import javax.swing.text.html.Option;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * Created by marc on 28.03.17.
+ * This class represents a group of toggle buttons in the sidebar.
+ * This class must be used together with an {@link ObservableList}, containing the objects which are to be shown in this LeftToggleGroup.
+ * For every object inside the {@link ObservableList} a {@link ToggleButton} is created, which is then shown inside this LeftToggleGroup.
+ * For the creation of the {@link ToggleButton}s a converter function is used, which must be passed to the constructor of this class.
+ *
+ * @author marc
+ * @since 28.03.17
  */
 public class LeftToggleGroup<E> extends LeftGroup {
+    /**
+     * The ToggleGroup to which all ToggleButtons in this LeftToggleGroup are added
+     */
     private final ToggleGroup toggleGroup;
+
+    /**
+     * An optional {@link ToggleButton}, which represents the selection of all categories at once.
+     * If this field is {@link Optional#empty()} no such button is used
+     */
     private final Optional<ToggleButton> allButton;
 
+    /**
+     * A {@link VBox} containing all shown {@link ToggleButton}s belonging to this LeftToggleGroup
+     */
     private final VBox toggleButtonBox;
 
+    /**
+     * An {@link ObservableList} containing all objects for which a {@link ToggleButton} is to be shown in this LeftToggleGroup
+     */
     private final ObservableList<E> elements;
-    private final ObservableList<? extends ToggleButton> mappedToggleButtons;
-    private final ObservableList<? extends ToggleButton> adhocToggleButtons;
 
-    public static <T> LeftToggleGroup<T> create(String name, Function<T, ? extends ToggleButton> converter) {
-        return new LeftToggleGroup<T>(name, converter);
-    }
+    /**
+     * An {@link ObservableList} that takes all objects in <code>elements</code> and converts them to a {@link ToggleButton}
+     */
+    private final MappedList<? extends ToggleButton, E> mappedToggleButtons;
 
-    public static <T> LeftToggleGroup<T> create(String name, Supplier<ToggleButton> allButtonSupplier, Function<T, ? extends ToggleButton> converter) {
-        return new LeftToggleGroup<T>(name, allButtonSupplier, converter);
-    }
+    /**
+     * An {@link ObservableList} containing both the <code>allButton</code>, if it's available, and the {@link ToggleButton}s
+     * inside <code>mappedToggleButtons</code>
+     */
+    private final AdhocList<? extends ToggleButton> adhocToggleButtons;
 
+    /**
+     * Constructor
+     *
+     * @param name              The title of this LeftToggleGroup
+     * @param allButtonSupplier A supplier function used to create the optional "all" ToggleButton. If no such button is needed null can be used
+     * @param converter         A converter function used to convert the source objects to ToggleButtons
+     */
     private LeftToggleGroup(String name, Supplier<ToggleButton> allButtonSupplier, Function<E, ? extends ToggleButton> converter) {
         super(name);
 
@@ -63,18 +88,67 @@ public class LeftToggleGroup<E> extends LeftGroup {
         this.getChildren().add(this.toggleButtonBox);
     }
 
+    /**
+     * Constructor
+     *
+     * @param name      The title of this LeftToggleGroup
+     * @param converter A converter function used to convert the source objects to ToggleButtons
+     */
     private LeftToggleGroup(String name, Function<E, ? extends ToggleButton> converter) {
         this(name, null, converter);
     }
 
+    /**
+     * This method creates a new LeftToggleGroup without an "all" categories ToggleButton using the given arguments
+     *
+     * @param name      The title of the new LeftToggleGroup
+     * @param converter The converter function used by the new LeftToggleGroup to convert the source objects to ToggleButtons
+     * @param <T>       The type of the source objects in the new LeftToggleGroup
+     * @return The newly created LeftToggleGroup with the given arguments
+     */
+    public static <T> LeftToggleGroup<T> create(String name, Function<T, ? extends ToggleButton> converter) {
+        return new LeftToggleGroup<T>(name, converter);
+    }
+
+    /**
+     * This method creates a new LeftToggleGroup using the given arguments
+     *
+     * @param name              The title of the new LeftToggleGroup
+     * @param allButtonSupplier The suppliert function used to create the "all" categories ToggleButton
+     * @param converter         The converter function used by the new LeftToggleGroup to convert the source objects to ToggleButtons
+     * @param <T>               The type of the source objects in the new LeftToggleGroup
+     * @return The newly created LeftToggleGroup with the given arguments
+     */
+    public static <T> LeftToggleGroup<T> create(String name, Supplier<ToggleButton> allButtonSupplier, Function<T, ? extends ToggleButton> converter) {
+        return new LeftToggleGroup<T>(name, allButtonSupplier, converter);
+    }
+
+    /**
+     * This method returns the {@link ObservableList} containing the source objects used to create the shown {@link ToggleButton}s.
+     * This {@link ObservableList} can be used to bind another {@link ObservableList} to this LeftToggleGroup
+     *
+     * @return The used {@link ObservableList}
+     */
     public ObservableList<E> getElements() {
         return this.elements;
     }
 
+    /**
+     * This method selects the "all" categories {@link ToggleButton} inside this LeftToggleGroup.
+     * If no such button exists this method does nothing
+     */
     public void selectAll() {
         this.allButton.ifPresent(button -> button.setSelected(true));
     }
 
+    /**
+     * This method selects the ToggleButton at a given position inside this LeftToggleGroup.
+     * For the position an optional "all" categories {@link ToggleButton} is ignored
+     *
+     * @param elementIndex The position of the to be selected {@link ToggleButton}
+     * @throws IllegalArgumentException This exception is thrown, if the given position <code>elementIndex</code>
+     *                                  is outside the range of the elements contained in this LeftToggleGroup
+     */
     public void select(int elementIndex) {
         if (elementIndex < 0 || elementIndex >= this.elements.size()) {
             throw new IllegalArgumentException(String.format("Element at index %d doesn't exist", elementIndex));
@@ -83,6 +157,13 @@ public class LeftToggleGroup<E> extends LeftGroup {
         }
     }
 
+    /**
+     * This method selects the ToggleButton belonging to a given element contained in the <code>elements</code> {@link ObservableList}
+     * inside this LeftToggleGroup.
+     *
+     * @param element The element, whose corresponding {@link javafx.scene.control.ToggleButton} is to be selected
+     * @throws IllegalArgumentException This exception is thrown, if the given <code>element</code> doesn't exist in this LeftToggleGroup
+     */
     public void select(E element) {
         this.select(this.elements.indexOf(element));
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleGroup.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftToggleGroup.java
@@ -30,7 +30,7 @@ public class LeftToggleGroup<E> extends LeftGroup {
     private final ObservableList<? extends ToggleButton> adhocToggleButtons;
 
     public static <T> LeftToggleGroup<T> create(String name, Function<T, ? extends ToggleButton> converter) {
-        return new LeftToggleGroup<T>(name, null, converter);
+        return new LeftToggleGroup<T>(name, converter);
     }
 
     public static <T> LeftToggleGroup<T> create(String name, Supplier<ToggleButton> allButtonSupplier, Function<T, ? extends ToggleButton> converter) {
@@ -61,6 +61,10 @@ public class LeftToggleGroup<E> extends LeftGroup {
         Bindings.bindContent(this.toggleButtonBox.getChildren(), this.adhocToggleButtons);
 
         this.getChildren().add(this.toggleButtonBox);
+    }
+
+    private LeftToggleGroup(String name, Function<E, ? extends ToggleButton> converter) {
+        this(name, null, converter);
     }
 
     public ObservableList<E> getElements() {

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/AdhocListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/AdhocListTest.java
@@ -97,7 +97,7 @@ public class AdhocListTest {
 
     @Test
     public void testListPermutation() {
-        SortedList<String> sortedList = FXCollections.observableArrayList(Arrays.asList("3", "7", "1", "5")).sorted();
+        SortedList<String> sortedList = FXCollections.observableArrayList(Arrays.asList("3", "7", "1", "5")).sorted(Comparator.naturalOrder());
         AdhocList<String> mappedList = new AdhocList<>(sortedList, "0");
 
         assertEquals(5, mappedList.size());

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/AdhocListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/AdhocListTest.java
@@ -1,0 +1,119 @@
+package org.phoenicis.javafx.views.common;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by marc on 26.04.17.
+ */
+public class AdhocListTest {
+
+    @Test
+    public void testListCreation() {
+        ObservableList<String> observableList = FXCollections.observableArrayList(Arrays.asList("3", "7", "1", "5"));
+        AdhocList<String> mappedList = new AdhocList<>(observableList, "0");
+
+        assertEquals(5, mappedList.size());
+        assertEquals("0", mappedList.get(0));
+        assertEquals("3", mappedList.get(1));
+        assertEquals("7", mappedList.get(2));
+        assertEquals("1", mappedList.get(3));
+        assertEquals("5", mappedList.get(4));
+    }
+
+    @Test
+    public void testListAdd() {
+        ObservableList<String> observableList = FXCollections.observableArrayList(Arrays.asList("3", "7", "1", "5"));
+        AdhocList<String> mappedList = new AdhocList<>(observableList, "0");
+
+        assertEquals(5, mappedList.size());
+        assertEquals("0", mappedList.get(0));
+        assertEquals("3", mappedList.get(1));
+        assertEquals("7", mappedList.get(2));
+        assertEquals("1", mappedList.get(3));
+        assertEquals("5", mappedList.get(4));
+
+        observableList.add("4");
+
+        assertEquals(6, mappedList.size());
+        assertEquals("0", mappedList.get(0));
+        assertEquals("3", mappedList.get(1));
+        assertEquals("7", mappedList.get(2));
+        assertEquals("1", mappedList.get(3));
+        assertEquals("5", mappedList.get(4));
+        assertEquals("4", mappedList.get(5));
+    }
+
+    @Test
+    public void testListRemove() {
+        ObservableList<String> observableList = FXCollections.observableArrayList(Arrays.asList("3", "7", "1", "5"));
+        AdhocList<String> mappedList = new AdhocList<>(observableList, "0");
+
+        assertEquals(5, mappedList.size());
+        assertEquals("0", mappedList.get(0));
+        assertEquals("3", mappedList.get(1));
+        assertEquals("7", mappedList.get(2));
+        assertEquals("1", mappedList.get(3));
+        assertEquals("5", mappedList.get(4));
+
+        observableList.remove(2);
+
+        assertEquals(4, mappedList.size());
+        assertEquals("0", mappedList.get(0));
+        assertEquals("3", mappedList.get(1));
+        assertEquals("7", mappedList.get(2));
+        assertEquals("5", mappedList.get(3));
+    }
+
+    @Test
+    public void testListUpdate() {
+        ObservableList<String> observableList = FXCollections.observableArrayList(Arrays.asList("3", "7", "1", "5"));
+        AdhocList<String> mappedList = new AdhocList<>(observableList, "0");
+
+        assertEquals(5, mappedList.size());
+        assertEquals("0", mappedList.get(0));
+        assertEquals("3", mappedList.get(1));
+        assertEquals("7", mappedList.get(2));
+        assertEquals("1", mappedList.get(3));
+        assertEquals("5", mappedList.get(4));
+
+        observableList.set(2, "4");
+
+        assertEquals(5, mappedList.size());
+        assertEquals("0", mappedList.get(0));
+        assertEquals("3", mappedList.get(1));
+        assertEquals("7", mappedList.get(2));
+        assertEquals("4", mappedList.get(3));
+        assertEquals("5", mappedList.get(4));
+    }
+
+    @Test
+    public void testListPermutation() {
+        SortedList<String> sortedList = FXCollections.observableArrayList(Arrays.asList("3", "7", "1", "5")).sorted();
+        AdhocList<String> mappedList = new AdhocList<>(sortedList, "0");
+
+        assertEquals(5, mappedList.size());
+        assertEquals("0", mappedList.get(0));
+        assertEquals("1", mappedList.get(1));
+        assertEquals("3", mappedList.get(2));
+        assertEquals("5", mappedList.get(3));
+        assertEquals("7", mappedList.get(4));
+
+        sortedList.comparatorProperty().set(Comparator.comparing(String::valueOf).reversed());
+
+        assertEquals(5, mappedList.size());
+        assertEquals("0", mappedList.get(0));
+        assertEquals("7", mappedList.get(1));
+        assertEquals("5", mappedList.get(2));
+        assertEquals("3", mappedList.get(3));
+        assertEquals("1", mappedList.get(4));
+    }
+}

--- a/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/AdhocListTest.java
+++ b/phoenicis-javafx/src/test/java/org/phoenicis/javafx/views/common/AdhocListTest.java
@@ -3,7 +3,6 @@ package org.phoenicis.javafx.views.common;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;


### PR DESCRIPTION
This PR does the following:
- refactored the LeftToggleGroup
- added an automatic removal from the ToggleGroup after a ToggleButton has been removed from the LeftToggleGroup
- added an AdhocList that combines an ObservableList with a number of normal objects to a new ObservableList
- improved the LeftToggleButton class to only fire an event after a click if the button isn't selected!
