### PR TITLE
Added a "Back" button to the apps and engines tabs

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/containers/ContainersController.java
@@ -134,7 +134,7 @@ public class ContainersController {
                             });
                 });
 
-                Platform.runLater(() -> viewContainers.showRightView(panel));
+                Platform.runLater(() -> viewContainers.clearChronicleNavigateTo(panel));
             });
         });
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationSideBar.java
@@ -2,12 +2,14 @@ package org.phoenicis.javafx.views.mainwindow.apps;
 
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
+import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ToggleButton;
-import javafx.scene.layout.VBox;
 import org.phoenicis.apps.dto.CategoryDTO;
+import org.phoenicis.javafx.views.mainwindow.MainWindowView;
 import org.phoenicis.javafx.views.mainwindow.ui.*;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.phoenicis.configuration.localisation.Localisation.translate;
@@ -35,6 +37,9 @@ public class ApplicationSideBar extends LeftSideBar {
     // the search bar user for application filtering/searching
     private SearchBox searchBar;
 
+    // an optional button used to return to the last page
+    private Button backButton;
+
     // the toggleable categories
     private LeftToggleGroup<CategoryDTO> categoryView;
 
@@ -53,12 +58,34 @@ public class ApplicationSideBar extends LeftSideBar {
     private Runnable onAllCategorySelection;
     private Consumer<CategoryDTO> onCategorySelection;
 
-    public ApplicationSideBar() {
+    /**
+     * Constructor
+     *
+     * @param mainWindow The main window view in which this sidebar resides
+     */
+    public ApplicationSideBar(MainWindowView<ApplicationSideBar> mainWindow) {
+        super(mainWindow);
+
         this.populateSearchBar();
         this.populateCategories();
         this.populateFilters();
 
-        this.getChildren().setAll(this.searchBar, new LeftSpacer(), this.categoryView, new LeftSpacer(), this.filterGroup);
+        this.showContent(Optional.empty());
+    }
+
+    public void showContent(Optional<MainWindowView.NavigationStep> lastNavigationStep) {
+        if (!lastNavigationStep.isPresent()) {
+            this.getChildren().setAll(this.searchBar, new LeftSpacer(), this.categoryView, new LeftSpacer(), this.filterGroup);
+        } else {
+            this.backButton = new Button("Back");
+
+            lastNavigationStep.get().getName().ifPresent(to -> this.backButton.setText(String.format("Back to %s", to)));
+
+            this.backButton.setWrapText(true);
+            this.backButton.setOnAction(event -> mainWindow.navigateToLast());
+
+            this.getChildren().setAll(this.backButton, new LeftSpacer(), this.categoryView, new LeftSpacer(), this.filterGroup);
+        }
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ViewApps.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ViewApps.java
@@ -26,8 +26,6 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import javafx.event.EventHandler;
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.ToggleButton;
 import javafx.scene.input.MouseEvent;
 import javafx.util.Duration;
 import org.phoenicis.apps.dto.ApplicationDTO;
@@ -37,7 +35,6 @@ import org.phoenicis.javafx.views.common.ExpandedList;
 import org.phoenicis.javafx.views.common.ThemeManager;
 import org.phoenicis.javafx.views.common.widget.MiniatureListWidget;
 import org.phoenicis.javafx.views.mainwindow.MainWindowView;
-import org.phoenicis.javafx.views.mainwindow.ui.*;
 import org.phoenicis.settings.SettingsManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,8 +42,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
-
-import static org.phoenicis.configuration.localisation.Localisation.translate;
 
 public class ViewApps extends MainWindowView<ApplicationSideBar> {
     private final Logger LOGGER = LoggerFactory.getLogger(ViewApps.class);
@@ -71,7 +66,7 @@ public class ViewApps extends MainWindowView<ApplicationSideBar> {
     public ViewApps(ThemeManager themeManager, SettingsManager settingsManager) {
         super("Apps", themeManager);
 
-        this.sideBar = new ApplicationSideBar();
+        this.sideBar = new ApplicationSideBar(this);
         this.availableApps = MiniatureListWidget.create(MiniatureListWidget.Element::create, (element, event) -> showAppDetails(element.getValue(), settingsManager));
 
         // initialising the category lists
@@ -97,26 +92,22 @@ public class ViewApps extends MainWindowView<ApplicationSideBar> {
         // set the category selection consumers
         this.sideBar.setOnCategorySelection(category -> {
             filter.setFilters(category.getApplications()::contains);
-            showAvailableApps();
+
+            this.clearChronicleNavigateTo("Applications", availableApps);
         });
         this.sideBar.setOnAllCategorySelection(() -> {
             filter.clearFilters();
-            showAvailableApps();
+
+            this.clearChronicleNavigateTo("Applications", availableApps);
         });
 
+        this.setOnViewChanged(sideBar::showContent);
         this.setSideBar(sideBar);
         this.showWait();
     }
 
     public void setOnSelectScript(Consumer<ScriptDTO> onSelectScript) {
         this.onSelectScript = onSelectScript;
-    }
-
-    /**
-     * Show available apps panel
-     */
-    public void showAvailableApps() {
-        showRightView(availableApps);
     }
 
     /**
@@ -130,7 +121,7 @@ public class ViewApps extends MainWindowView<ApplicationSideBar> {
             this.filter.clearAll();
             this.sideBar.selectAllCategories();
 
-            this.showAvailableApps();
+            this.clearChronicleNavigateTo("Applications", availableApps);
         });
     }
 
@@ -141,7 +132,8 @@ public class ViewApps extends MainWindowView<ApplicationSideBar> {
     private void showAppDetails(ApplicationDTO application, SettingsManager settingsManager) {
         final AppPanel appPanel = new AppPanel(application, themeManager, settingsManager);
         appPanel.setOnScriptInstall(this::installScript);
-        showRightView(appPanel);
+
+        this.navigateTo(appPanel);
     }
 
     private void installScript(ScriptDTO scriptDTO) {
@@ -150,7 +142,6 @@ public class ViewApps extends MainWindowView<ApplicationSideBar> {
 
     private void clearFilterText() {
         this.filter.setFilterText("");
-        this.showAvailableApps();
     }
 
     private void processFilterText(String filterText) {
@@ -165,7 +156,5 @@ public class ViewApps extends MainWindowView<ApplicationSideBar> {
         });
 
         this.pause.playFromStart();
-
-        this.showAvailableApps();
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerSideBar.java
@@ -5,6 +5,7 @@ import javafx.collections.ObservableList;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.layout.VBox;
 import org.phoenicis.containers.dto.ContainerDTO;
+import org.phoenicis.javafx.views.mainwindow.MainWindowView;
 import org.phoenicis.javafx.views.mainwindow.ui.*;
 
 import java.util.function.Consumer;
@@ -43,8 +44,8 @@ public class ContainerSideBar extends LeftSideBar {
     /**
      * Constructor
      */
-    public ContainerSideBar() {
-        super();
+    public ContainerSideBar(MainWindowView<ContainerSideBar> mainWindow) {
+        super(mainWindow);
 
         this.populateSearchBar();
         this.populateContainers();

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ViewContainers.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ViewContainers.java
@@ -48,7 +48,7 @@ public class ViewContainers extends MainWindowView<ContainerSideBar> {
     public ViewContainers(ThemeManager themeManager) {
         super("Containers", themeManager);
 
-        this.sideBar = new ContainerSideBar();
+        this.sideBar = new ContainerSideBar(this);
 
         this.containers = FXCollections.observableArrayList();
 
@@ -59,7 +59,7 @@ public class ViewContainers extends MainWindowView<ContainerSideBar> {
         this.initSelectContainerPane();
 
         this.setSideBar(sideBar);
-        this.showRightView(selectContainerPanel);
+        this.navigateTo(selectContainerPanel);
     }
 
     public void setOnSelectContainer(Consumer<ContainerDTO> onSelectContainer) {
@@ -74,9 +74,7 @@ public class ViewContainers extends MainWindowView<ContainerSideBar> {
         Platform.runLater(() -> {
             this.containers.setAll(containers);
 
-            this.initSelectContainerPane();
-
-            showRightView(selectContainerPanel);
+            this.clearChronicleNavigateTo(selectContainerPanel);
         });
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
@@ -2,12 +2,14 @@ package org.phoenicis.javafx.views.mainwindow.engines;
 
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
+import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ToggleButton;
-import javafx.scene.layout.VBox;
 import org.phoenicis.engines.dto.EngineCategoryDTO;
+import org.phoenicis.javafx.views.mainwindow.MainWindowView;
 import org.phoenicis.javafx.views.mainwindow.ui.*;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.phoenicis.configuration.localisation.Localisation.translate;
@@ -35,6 +37,9 @@ public class EngineSideBar extends LeftSideBar {
     // the search bar used for filtering
     private SearchBox searchBar;
 
+    // an optional button used to return to the last page
+    private Button backButton;
+
     // the button group containing a button for all engine categories
     private LeftToggleGroup<EngineCategoryDTO> categoryView;
 
@@ -57,15 +62,32 @@ public class EngineSideBar extends LeftSideBar {
 
     /**
      * Constructor
+     *
+     * @param mainWindow The main window view in which this sidebar resides
      */
-    public EngineSideBar() {
-        super();
+    public EngineSideBar(MainWindowView<EngineSideBar> mainWindow) {
+        super(mainWindow);
 
         this.populateSearchBar();
         this.populateEngineCategories();
         this.populateInstallationFilters();
 
-        this.getChildren().setAll(this.searchBar, new LeftSpacer(), this.categoryView, new LeftSpacer(), this.installationFilterGroup);
+        this.showContent(Optional.empty());
+    }
+
+    public void showContent(Optional<MainWindowView.NavigationStep> lastNavigationStep) {
+        if (!lastNavigationStep.isPresent()) {
+            this.getChildren().setAll(this.searchBar, new LeftSpacer(), this.categoryView, new LeftSpacer(), this.installationFilterGroup);
+        } else {
+            this.backButton = new Button("Back");
+
+            lastNavigationStep.get().getName().ifPresent(to -> this.backButton.setText(String.format("Back to %s", to)));
+
+            this.backButton.setWrapText(true);
+            this.backButton.setOnAction(event -> mainWindow.navigateToLast());
+
+            this.getChildren().setAll(this.backButton, new LeftSpacer(), this.categoryView, new LeftSpacer(), this.installationFilterGroup);
+        }
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/ViewEngines.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/ViewEngines.java
@@ -58,7 +58,7 @@ public class ViewEngines extends MainWindowView<EngineSideBar> {
     public ViewEngines(ThemeManager themeManager, String wineEnginesPath) {
         super("Engines", themeManager);
 
-        this.sideBar = new EngineSideBar();
+        this.sideBar = new EngineSideBar(this);
 
         this.engineCategories = FXCollections.observableArrayList();
         this.engineSubCategories = FXCollections.observableArrayList();
@@ -87,6 +87,7 @@ public class ViewEngines extends MainWindowView<EngineSideBar> {
 
         Bindings.bindContent(availableEngines.getTabs(), mappedSubCategoryTabs);
 
+        this.setOnViewChanged(sideBar::showContent);
         this.setSideBar(sideBar);
         this.showWait();
     }
@@ -110,12 +111,6 @@ public class ViewEngines extends MainWindowView<EngineSideBar> {
         availableEngines.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
     }
 
-    // TODO: delete this method because it doesn't do what it promises, namely showing the wine versions tab
-    @Deprecated
-    public void showWineVersions() {
-        showRightView(availableEngines);
-    }
-
     public void populate(List<EngineCategoryDTO> engineCategoryDTOS) {
         Platform.runLater(() -> {
             this.engineCategories.setAll(engineCategoryDTOS);
@@ -124,7 +119,7 @@ public class ViewEngines extends MainWindowView<EngineSideBar> {
                 this.sideBar.selectFirstEngineCategory();
             }
 
-            this.showAvailableEngines();
+            this.clearChronicleNavigateTo("Engines", availableEngines);
         });
     }
 
@@ -133,12 +128,8 @@ public class ViewEngines extends MainWindowView<EngineSideBar> {
         this.engineSubCategories.setAll(category.getSubCategories());
     }
 
-    public void showAvailableEngines() {
-        showRightView(availableEngines);
-    }
-
     private void selectCategory(EngineCategoryDTO category) {
-        this.showRightView(availableEngines);
+        this.clearChronicleNavigateTo(String.format("%s engines", category.getName()), availableEngines);
         this.populateEngines(category);
     }
 
@@ -146,7 +137,8 @@ public class ViewEngines extends MainWindowView<EngineSideBar> {
         currentEnginePanel = new EnginePanel(engineDTO);
         currentEnginePanel.setOnEngineInstall(this::installEngine);
         currentEnginePanel.setOnEngineDelete(this::deleteEngine);
-        showRightView(currentEnginePanel);
+
+        this.navigateTo(currentEnginePanel);
     }
 
     private void processFilterText(String filterText) {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibrarySideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibrarySideBar.java
@@ -2,6 +2,7 @@ package org.phoenicis.javafx.views.mainwindow.library;
 
 import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
+import org.phoenicis.javafx.views.mainwindow.MainWindowView;
 import org.phoenicis.javafx.views.mainwindow.ui.*;
 import org.phoenicis.library.dto.ShortcutDTO;
 
@@ -70,8 +71,8 @@ public class LibrarySideBar extends LeftSideBar {
      *
      * @param applicationName The name of this application (normally "PlayOnLinux")
      */
-    public LibrarySideBar(String applicationName) {
-        super();
+    public LibrarySideBar(String applicationName, MainWindowView<LibrarySideBar> mainWindow) {
+        super(mainWindow);
 
         this.applicationName = applicationName;
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/ViewLibrary.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/ViewLibrary.java
@@ -50,12 +50,12 @@ public class ViewLibrary extends MainWindowView<LibrarySideBar> {
         super("Library", themeManager);
         this.getStyleClass().add("mainWindowScene");
 
-        this.sideBar = new LibrarySideBar(applicationName);
+        this.sideBar = new LibrarySideBar(applicationName, this);
 
         this.drawContent();
 
         this.setSideBar(sideBar);
-        this.showRightView(libraryTabs);
+        this.navigateTo(libraryTabs);
     }
 
     public void setOnShortcutSelected(Consumer<ShortcutDTO> onShortcutSelected) {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/SettingsSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/SettingsSideBar.java
@@ -4,6 +4,7 @@ import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.layout.VBox;
+import org.phoenicis.javafx.views.mainwindow.MainWindowView;
 import org.phoenicis.javafx.views.mainwindow.ui.LeftSideBar;
 import org.phoenicis.javafx.views.mainwindow.ui.LeftToggleButton;
 import org.phoenicis.javafx.views.mainwindow.ui.LeftToggleGroup;
@@ -27,8 +28,8 @@ public class SettingsSideBar extends LeftSideBar {
     /**
      * Constructor
      */
-    public SettingsSideBar() {
-        super();
+    public SettingsSideBar(MainWindowView<SettingsSideBar> mainWindow) {
+        super(mainWindow);
 
         this.populate();
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/ViewSettings.java
@@ -57,9 +57,9 @@ public class ViewSettings extends MainWindowView<SettingsSideBar> {
 
         this.initializeSettingsItems();
 
-        this.sideBar = new SettingsSideBar();
+        this.sideBar = new SettingsSideBar(this);
 
-        this.sideBar.setOnSelectSettingsItem(this::showRightView);
+        this.sideBar.setOnSelectSettingsItem(this::clearChronicleNavigateTo);
 
         this.sideBar.bindSettingsItems(this.settingsItems);
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftSideBar.java
@@ -24,11 +24,15 @@ import javafx.scene.Node;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.Border;
 import javafx.scene.layout.VBox;
+import org.phoenicis.javafx.views.mainwindow.MainWindowView;
 
 public abstract class LeftSideBar extends VBox {
+    protected MainWindowView<? extends LeftSideBar> mainWindow;
 
-    public LeftSideBar() {
+    public LeftSideBar(MainWindowView<? extends LeftSideBar> mainWindow) {
         super();
+
+        this.mainWindow = mainWindow;
 
         this.getStyleClass().add("leftPane");
     }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/scriptui/JavaFxUiConfiguration.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/scriptui/JavaFxUiConfiguration.java
@@ -73,7 +73,7 @@ public class JavaFxUiConfiguration implements UiConfiguration {
         return title -> {
             final ProgressUiJavaFXImplementation progressUi = new ProgressUiJavaFXImplementation();
             viewsConfiguration.viewEngines().showProgress(progressUi);
-            progressUi.setOnShouldClose(() -> viewsConfiguration.viewEngines().showWineVersions());
+
             return progressUi;
         };
     }


### PR DESCRIPTION
This PR addresses #733. 
It adds a navigation chronicle to the `MainWindowView`, which is then used by the sidebar and the windows themselves to implement the back functionality.

![grafik](https://cloud.githubusercontent.com/assets/18488086/25555406/6cdbf142-2ce6-11e7-949f-d012784e4787.png)

![grafik](https://cloud.githubusercontent.com/assets/18488086/25555407/721f51a8-2ce6-11e7-97e0-b3624bdae8e4.png)

![grafik](https://cloud.githubusercontent.com/assets/18488086/25555409/759edca4-2ce6-11e7-9420-b9b57650c258.png)