### PR TITLE
Replaced byte[] with icon and miniature data in ApplicationDTO and ShortcutDTO with URI objects

### DIFF
--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/dto/ApplicationDTO.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/dto/ApplicationDTO.java
@@ -21,6 +21,7 @@ package org.phoenicis.apps.dto;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -33,8 +34,8 @@ import java.util.List;
 public class ApplicationDTO {
     private final String name;
     private final String description;
-    private final byte[] icon;
-    private final List<byte[]> miniatures;
+    private final URI icon;
+    private final List<URI> miniatures;
     private final List<ScriptDTO> scripts;
     private final List<ResourceDTO> resources;
 
@@ -51,11 +52,11 @@ public class ApplicationDTO {
         return resources;
     }
 
-    public byte[] getIcon() {
+    public URI getIcon() {
         return icon;
     }
 
-    public List<byte[]> getMiniatures() {
+    public List<URI> getMiniatures() {
         return miniatures;
     }
 
@@ -79,8 +80,8 @@ public class ApplicationDTO {
     public static class Builder {
         private String name;
         private String description;
-        private byte[] icon;
-        private List<byte[]> miniatures = new ArrayList<>();
+        private URI icon;
+        private List<URI> miniatures = new ArrayList<>();
         private List<ScriptDTO> scripts = new ArrayList<>();
         private List<ResourceDTO> resources = new ArrayList<>();
 
@@ -112,12 +113,12 @@ public class ApplicationDTO {
             return this;
         }
 
-        public Builder withIcon(byte[] icon) {
+        public Builder withIcon(URI icon) {
             this.icon = icon;
             return this;
         }
 
-        public Builder withMiniatures(List<byte[]> miniatures) {
+        public Builder withMiniatures(List<URI> miniatures) {
             this.miniatures = miniatures;
             return this;
         }

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/repository/ClasspathRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/repository/ClasspathRepository.java
@@ -33,6 +33,8 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -107,7 +109,7 @@ public class ClasspathRepository implements Repository {
                 .withMiniatures(buildMiniatures(categoryFileName, applicationFileName)).build();
     }
 
-    private List<byte[]> buildMiniatures(String categoryFileName, String applicationFileName) throws IOException {
+    private List<URI> buildMiniatures(String categoryFileName, String applicationFileName) throws IOException {
         final String applicationScanClassPath = packagePath + "/" + categoryFileName + "/" + applicationFileName
                 + "/miniatures/";
         Resource[] resources = resourceResolver.getResources(applicationScanClassPath + "/*");
@@ -115,9 +117,10 @@ public class ClasspathRepository implements Repository {
         return Arrays.stream(resources).map(resource -> {
             final String resourceFile = packagePath + "/" + categoryFileName + "/" + applicationFileName
                     + "/miniatures/" + resource.getFilename();
+
             try {
-                return IOUtils.toByteArray(getClass().getResourceAsStream(resourceFile));
-            } catch (IOException e) {
+                return getClass().getResource(resourceFile).toURI();
+            } catch (URISyntaxException e) {
                 return null;
             }
         }).collect(Collectors.toList());

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/repository/LocalRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/repository/LocalRepository.java
@@ -34,10 +34,9 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.net.URI;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class LocalRepository implements Repository {
     private final static Logger LOGGER = LoggerFactory.getLogger(LocalRepository.class);
@@ -135,22 +134,13 @@ public class LocalRepository implements Repository {
         return results;
     }
 
-    private List<byte[]> fetchMiniatures(File miniaturesDirectory) throws IOException {
-        final List<byte[]> miniatures = new ArrayList<>();
+    private List<URI> fetchMiniatures(File miniaturesDirectory) throws IOException {
+
         final File[] miniatureFiles = miniaturesDirectory.listFiles();
 
-        if (miniatureFiles != null) {
-            for (File miniatureFile : miniatureFiles) {
-                if (!miniatureFile.isDirectory() && !miniatureFile.getName().startsWith(".")) {
-                    if ("main.png".equals(miniatureFile.getName())) {
-                        miniatures.add(0, IOUtils.toByteArray(new FileInputStream(miniatureFile)));
-                    } else {
-                        miniatures.add(IOUtils.toByteArray(new FileInputStream(miniatureFile)));
-                    }
-                }
-            }
-        }
-        return miniatures;
+        return Arrays.stream(miniatureFiles)
+                .filter(miniatureFile -> !miniatureFile.isDirectory() && !miniatureFile.getName().startsWith("."))
+                .map(File::toURI).collect(Collectors.toList());
     }
 
     private List<ResourceDTO> fetchResources(File applicationDirectory) {

--- a/phoenicis-apps/src/main/java/org/phoenicis/apps/repository/MergeableRepository.java
+++ b/phoenicis-apps/src/main/java/org/phoenicis/apps/repository/MergeableRepository.java
@@ -3,7 +3,9 @@
  */
 package org.phoenicis.apps.repository;
 
+import java.net.URI;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -105,16 +107,12 @@ public abstract class MergeableRepository implements Repository {
         final List<ResourceDTO> resources = mergeListOfDtos(leftApplication.getResources(),
                 rightApplication.getResources(), ResourceDTO::getName, ResourceDTO.nameComparator());
 
-        final Set<ByteBuffer> mergeMiniaturesSet = new HashSet<>();
-        leftApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
-        rightApplication.getMiniatures().forEach(miniature -> mergeMiniaturesSet.add(ByteBuffer.wrap(miniature)));
-
-        final List<byte[]> mergeMiniatures = new ArrayList<>();
-        mergeMiniaturesSet.forEach(miniature -> mergeMiniatures.add(miniature.array()));
+        final Set<URI> mergeMiniaturesSet = new HashSet<URI>(leftApplication.getMiniatures());
+        mergeMiniaturesSet.addAll(rightApplication.getMiniatures());
 
         return new ApplicationDTO.Builder().withName(leftApplication.getName()).withResources(resources)
                 .withScripts(scripts).withDescription(leftApplication.getDescription())
-                .withIcon(leftApplication.getIcon()).withMiniatures(mergeMiniatures).build();
+                .withIcon(leftApplication.getIcon()).withMiniatures(new ArrayList<>(mergeMiniaturesSet)).build();
     }
 
     protected <T> List<T> mergeListOfDtos(List<T> leftList, List<T> rightList, Function<T, String> nameSupplier,

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widget/MiniatureListWidget.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widget/MiniatureListWidget.java
@@ -170,14 +170,12 @@ public final class MiniatureListWidget<E> extends ScrollPane {
 
         public static Element<ApplicationDTO> create(ApplicationDTO application) {
             return new Element<ApplicationDTO>(application, application.getName(), application.getMiniatures().isEmpty()
-                    ? new StaticMiniature()
-                    : new StaticMiniature(new Image(new ByteArrayInputStream(application.getMiniatures().get(0)))));
+                    ? new StaticMiniature() : new StaticMiniature(application.getMiniatures().get(0)));
         }
 
         public static Element<ShortcutDTO> create(ShortcutDTO shortcut) {
-            return new Element<ShortcutDTO>(shortcut, shortcut.getName(),
-                    shortcut.getMiniature() == null ? new StaticMiniature()
-                            : new StaticMiniature(new Image(new ByteArrayInputStream(shortcut.getMiniature()))));
+            return new Element<ShortcutDTO>(shortcut, shortcut.getName(), shortcut.getMiniature() == null
+                    ? new StaticMiniature() : new StaticMiniature(shortcut.getMiniature()));
         }
 
         public static Element<EngineVersionDTO> create(EngineVersionDTO engineVersion, boolean installed) {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widget/StaticMiniature.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widget/StaticMiniature.java
@@ -20,19 +20,29 @@ package org.phoenicis.javafx.views.common.widget;
 
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.Region;
 
-public class StaticMiniature extends ImageView {
-    public static final Image DEFAULT_MINIATURE = new Image(
-            MiniatureListWidget.class.getResource("defaultMiniature.png").toExternalForm());
+import java.net.URI;
+import java.net.URISyntaxException;
 
-    public static final Image WINE_MINIATURE = new Image(
-            MiniatureListWidget.class.getResource("wineMiniature.png").toExternalForm());
+public class StaticMiniature extends Region {
+    public static URI DEFAULT_MINIATURE;
+    public static URI WINE_MINIATURE;
 
-    public StaticMiniature(Image defaultImage) {
-        super(defaultImage);
-        this.setFitWidth(120);
-        this.setFitHeight(90);
+    static {
+        try {
+            DEFAULT_MINIATURE = MiniatureListWidget.class.getResource("defaultMiniature.png").toURI();
+            WINE_MINIATURE = MiniatureListWidget.class.getResource("wineMiniature.png").toURI();
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public StaticMiniature(URI miniatureImageUri) {
+        super();
+
         this.getStyleClass().add("miniatureImage");
+        this.setStyle(String.format("-fx-background-image: url(\"%s\");", miniatureImageUri.toString()));
     }
 
     public StaticMiniature() {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/AppPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/AppPanel.java
@@ -34,8 +34,10 @@ import org.phoenicis.javafx.views.common.ThemeManager;
 import org.phoenicis.settings.SettingsManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.ranges.Range;
 
 import java.io.ByteArrayInputStream;
+import java.net.URI;
 import java.net.URL;
 import java.util.function.Consumer;
 
@@ -100,14 +102,15 @@ final class AppPanel extends VBox {
         final ScrollPane miniaturesPaneWrapper = new ScrollPane(miniaturesPane);
         miniaturesPaneWrapper.getStyleClass().add("appPanelMiniaturesPaneWrapper");
 
-        for (byte[] miniatureBytes : applicationDTO.getMiniatures()) {
-            Image image = new Image(new ByteArrayInputStream(miniatureBytes));
-            ImageView imageView = new ImageView(image);
-            imageView.fitHeightProperty().bind(miniaturesPaneWrapper.heightProperty().multiply(0.8));
-            imageView.setPreserveRatio(true);
-            imageView.setSmooth(true);
-            imageView.setCache(true);
-            miniaturesPane.getChildren().add(imageView);
+        for (URI miniatureUri : applicationDTO.getMiniatures()) {
+            Region image = new Region();
+            image.getStyleClass().add("appMiniature");
+            image.setStyle(String.format("-fx-background-image: url('%s');", miniatureUri.toString()));
+
+            image.prefHeightProperty().bind(miniaturesPaneWrapper.heightProperty().multiply(0.8));
+            image.prefWidthProperty().bind(image.prefHeightProperty().multiply(1.5));
+
+            miniaturesPane.getChildren().add(image);
         }
 
         getChildren().addAll(descriptionWidget, miniaturesPaneWrapper);

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.css
@@ -415,6 +415,12 @@
     -fx-padding: 1em;
 }
 
+.appMiniature {
+    -fx-background-size: contain;
+    -fx-background-repeat: no-repeat;
+    -fx-background-position: left center;
+}
+
 .appPanelMiniaturesPaneWrapper {
     -fx-padding: 0em;
     -fx-border-width: 0;
@@ -480,6 +486,11 @@
 .miniatureImage {
     -fx-border-radius: 0;
     -fx-background-radius: 0;
+    -fx-background-size: contain;
+    -fx-background-repeat: no-repeat;
+    -fx-background-position: center;
+    -fx-pref-width: 15em;
+    -fx-pref-height: 12em;
 }
 
 .miniatureText {

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/dark/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/dark/main.css
@@ -218,6 +218,12 @@
     -fx-padding: 1em;
 }
 
+.appMiniature {
+    -fx-background-size: contain;
+    -fx-background-repeat: no-repeat;
+    -fx-background-position: left center;
+}
+
 .appPanelMiniaturesPaneWrapper {
     -fx-padding: 0px;
     -fx-border-width: 0;
@@ -282,6 +288,11 @@
 .miniatureImage {
     -fx-border-radius: 0.4em;
     -fx-background-radius: 0.4em;
+    -fx-background-size: contain;
+    -fx-background-repeat: no-repeat;
+    -fx-background-position: center;
+    -fx-pref-width: 15em;
+    -fx-pref-height: 12em;
 }
 
 .miniatureText {

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.css
@@ -215,7 +215,7 @@
 }
 
 .appMiniature {
-    -fx-background-size: cover;
+    -fx-background-size: contain;
     -fx-background-repeat: no-repeat;
     -fx-background-position: left center;
 }
@@ -290,7 +290,7 @@
 .miniatureImage {
     -fx-border-radius: 0.4em;
     -fx-background-radius: 0.4em;
-    -fx-background-size: stretch;
+    -fx-background-size: contain;
     -fx-background-repeat: no-repeat;
     -fx-background-position: center;
     -fx-pref-width: 15em;

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.css
@@ -214,6 +214,12 @@
     -fx-padding: 0.5em;
 }
 
+.appMiniature {
+    -fx-background-size: cover;
+    -fx-background-repeat: no-repeat;
+    -fx-background-position: left center;
+}
+
 .appPanelMiniaturesPaneWrapper {
     -fx-padding: 0px;
     -fx-border-width: 0;
@@ -284,6 +290,11 @@
 .miniatureImage {
     -fx-border-radius: 0.4em;
     -fx-background-radius: 0.4em;
+    -fx-background-size: stretch;
+    -fx-background-repeat: no-repeat;
+    -fx-background-position: center;
+    -fx-pref-width: 15em;
+    -fx-pref-height: 12em;
 }
 
 .miniatureText {

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.css
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.css
@@ -461,6 +461,12 @@
     -fx-padding: 1em;
 }
 
+.appMiniature {
+    -fx-background-size: contain;
+    -fx-background-repeat: no-repeat;
+    -fx-background-position: left center;
+}
+
 .appPanelMiniaturesPaneWrapper {
     -fx-padding: 0px;
     -fx-border-width: 0;
@@ -526,6 +532,11 @@
 .miniatureImage {
     -fx-border-radius: 8px;
     -fx-background-radius: 8px;
+    -fx-background-size: contain;
+    -fx-background-repeat: no-repeat;
+    -fx-background-position: center;
+    -fx-pref-width: 15em;
+    -fx-pref-height: 12em;
 }
 
 .miniatureText {

--- a/phoenicis-library/src/main/java/org/phoenicis/library/LibraryManager.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/LibraryManager.java
@@ -25,7 +25,10 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -84,19 +87,23 @@ public class LibraryManager {
         final File descriptionFile = new File(shortcutDirectory, baseName + ".description");
 
         try {
-            final byte[] icon = IOUtils.toByteArray(iconFile.exists() ? new FileInputStream(iconFile)
-                    : getClass().getResourceAsStream("phoenicis.png"));
-            final byte[] miniature = IOUtils.toByteArray(miniatureFile.exists() ? new FileInputStream(miniatureFile)
-                    : getClass().getResourceAsStream("defaultMiniature.png"));
+            final URI icon = iconFile.exists() ? iconFile.toURI() : getClass().getResource("phoenicis.png").toURI();
+            final URI miniature = miniatureFile.exists() ? miniatureFile.toURI()
+                    : getClass().getResource("defaultMiniature.png").toURI();
+
             final String description = descriptionFile.exists()
                     ? IOUtils.toString(new FileInputStream(descriptionFile), "UTF-8") : "";
+
             return new ShortcutDTO.Builder().withName(baseName)
                     .withScript(IOUtils.toString(new FileInputStream(file), "UTF-8")).withIcon(icon)
                     .withMiniature(miniature).withDescription(description).build();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        } catch (FileNotFoundException e) {
+            throw new IllegalStateException(e);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
-
     }
 
     public void refresh() {

--- a/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutManager.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/ShortcutManager.java
@@ -65,10 +65,10 @@ public class ShortcutManager {
                 FileUtils.writeStringToFile(descriptionFile, shortcutDTO.getDescription(), ENCODING);
             }
             if (shortcutDTO.getIcon() != null) {
-                FileUtils.writeByteArrayToFile(iconFile, shortcutDTO.getIcon());
+                FileUtils.copyFile(new File(shortcutDTO.getIcon()), iconFile);
             }
             if (shortcutDTO.getMiniature() != null) {
-                FileUtils.writeByteArrayToFile(miniatureFile, shortcutDTO.getMiniature());
+                FileUtils.copyFile(new File(shortcutDTO.getMiniature()), miniatureFile);
             }
         } catch (IOException e) {
             LOGGER.warn("Error while creating shortcut", e);

--- a/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutDTO.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutDTO.java
@@ -21,14 +21,15 @@ package org.phoenicis.library.dto;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
+import java.net.URI;
 import java.util.Comparator;
 
 @JsonDeserialize(builder = ShortcutDTO.Builder.class)
 public class ShortcutDTO {
     private final String name;
     private final String description;
-    private final byte[] icon;
-    private final byte[] miniature;
+    private final URI icon;
+    private final URI miniature;
     private final String script;
 
     private ShortcutDTO(Builder builder) {
@@ -39,11 +40,11 @@ public class ShortcutDTO {
         script = builder.script;
     }
 
-    public byte[] getIcon() {
+    public URI getIcon() {
         return icon;
     }
 
-    public byte[] getMiniature() {
+    public URI getMiniature() {
         return miniature;
     }
 
@@ -67,8 +68,8 @@ public class ShortcutDTO {
     public static class Builder {
         private String name;
         private String description;
-        private byte[] icon;
-        private byte[] miniature;
+        private URI icon;
+        private URI miniature;
         private String script;
 
         public Builder() {
@@ -93,12 +94,12 @@ public class ShortcutDTO {
             return this;
         }
 
-        public Builder withIcon(byte[] icon) {
+        public Builder withIcon(URI icon) {
             this.icon = icon;
             return this;
         }
 
-        public Builder withMiniature(byte[] miniature) {
+        public Builder withMiniature(URI miniature) {
             this.miniature = miniature;
             return this;
         }


### PR DESCRIPTION
This PR replaces the byte arrays, that contain the image data corresponding to shortcuts and applications with `URI` objects.
The result now looks like this:
![grafik](https://cloud.githubusercontent.com/assets/18488086/25773795/6c6599ae-3284-11e7-97a4-a7b70375e719.png)
![grafik](https://cloud.githubusercontent.com/assets/18488086/25773797/6e84f82e-3284-11e7-9d33-1a7139998dec.png)
![grafik](https://cloud.githubusercontent.com/assets/18488086/25773801/703c0374-3284-11e7-9594-012d773de236.png)
![grafik](https://cloud.githubusercontent.com/assets/18488086/25773823/eb781f00-3284-11e7-9803-72ab6e388fa9.png)

I know that the proportions are a bit off now. It would be nice if someone can correct them at a later time.

A follow up PR should concentrate on the problem with the ShortcutDTO content.
When a `ShortcutDTO` is created, it receives the `URI` objects from the corresponding `ApplicationDTO` object. Only after a restart at a later time the URI will be corrected to link to a copy of the icon/miniature that belongs to the shortcut.