### PR TITLE
use latest release of dependencies

### DIFF
--- a/phoenicis-apps/pom.xml
+++ b/phoenicis-apps/pom.xml
@@ -28,6 +28,10 @@
 
     <artifactId>phoenicis-apps</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -102,13 +106,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.8.1</version>
         </dependency>
 
 		<dependency>
 		   	<groupId>org.eclipse.jgit</groupId>
 		   	<artifactId>org.eclipse.jgit</artifactId>
-			<version>4.6.1.201703071140-r</version>
+			<version>4.7.0.201704051617-r</version>
 		</dependency>
 
     </dependencies>

--- a/phoenicis-cli/pom.xml
+++ b/phoenicis-cli/pom.xml
@@ -29,6 +29,10 @@
 
     <artifactId>phoenicis-cli</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.phoenicis</groupId>
@@ -63,7 +67,7 @@
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.9.0</version>
+            <version>0.9.4</version>
         </dependency>
 
         <dependency>

--- a/phoenicis-configuration/pom.xml
+++ b/phoenicis-configuration/pom.xml
@@ -29,6 +29,10 @@
 
     <artifactId>phoenicis-configuration</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -51,7 +55,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>21.0</version>
         </dependency>
 
     </dependencies>

--- a/phoenicis-containers/pom.xml
+++ b/phoenicis-containers/pom.xml
@@ -29,6 +29,10 @@
 
     <artifactId>phoenicis-containers</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/phoenicis-dist/pom.xml
+++ b/phoenicis-dist/pom.xml
@@ -26,6 +26,10 @@
 	</parent>
 	<artifactId>phoenicis-dist</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.phoenicis</groupId>

--- a/phoenicis-engines/pom.xml
+++ b/phoenicis-engines/pom.xml
@@ -29,6 +29,10 @@
 
     <artifactId>phoenicis-engines</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.phoenicis</groupId>

--- a/phoenicis-entities/pom.xml
+++ b/phoenicis-entities/pom.xml
@@ -29,5 +29,9 @@
 
     <artifactId>phoenicis-entities</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
 
 </project>

--- a/phoenicis-javafx/pom.xml
+++ b/phoenicis-javafx/pom.xml
@@ -29,6 +29,7 @@
     <artifactId>phoenicis-javafx</artifactId>
 
     <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
         <testfx.version>4.0.6-alpha</testfx.version>
     </properties>
 
@@ -87,7 +88,7 @@
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.9.0</version>
+            <version>0.9.4</version>
         </dependency>
 
         <dependency>
@@ -138,7 +139,7 @@
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>openjfx-monocle</artifactId>
-            <version>1.8.0_20</version>
+            <version>8u76-b04</version>
             <scope>test</scope>
         </dependency>
 

--- a/phoenicis-library/pom.xml
+++ b/phoenicis-library/pom.xml
@@ -28,6 +28,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>phoenicis-library</artifactId>
+
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.phoenicis</groupId>
@@ -56,7 +61,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.8.1</version>
         </dependency>
 
         <dependency>

--- a/phoenicis-multithreading/pom.xml
+++ b/phoenicis-multithreading/pom.xml
@@ -29,6 +29,10 @@
 
     <artifactId>phoenicis-multithreading</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/phoenicis-scripts/pom.xml
+++ b/phoenicis-scripts/pom.xml
@@ -29,6 +29,10 @@
 
     <artifactId>phoenicis-scripts</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/phoenicis-settings/pom.xml
+++ b/phoenicis-settings/pom.xml
@@ -28,6 +28,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>phoenicis-settings</artifactId>
+
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.phoenicis</groupId>
@@ -56,7 +61,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.8.1</version>
         </dependency>
 
         <dependency>

--- a/phoenicis-tests/pom.xml
+++ b/phoenicis-tests/pom.xml
@@ -29,6 +29,10 @@
 
     <artifactId>phoenicis-tests</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/phoenicis-tools/pom.xml
+++ b/phoenicis-tools/pom.xml
@@ -28,6 +28,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>phoenicis-tools</artifactId>
+
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.phoenicis</groupId>
@@ -75,7 +80,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.9</version>
+            <version>1.13</version>
         </dependency>
 
         <dependency>
@@ -87,7 +92,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.8.1</version>
         </dependency>
 
         <dependency>
@@ -115,7 +120,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>3.9.2</version>
+            <version>3.10.7</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/phoenicis-win32/pom.xml
+++ b/phoenicis-win32/pom.xml
@@ -29,17 +29,21 @@
 
     <artifactId>phoenicis-win32</artifactId>
 
+    <properties>
+        <project.settings>${project.basedir}/../settings</project.settings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.5</version>
         </dependency>
 
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 	</modules>
 
 	<properties>
+		<project.settings>${project.basedir}/settings</project.settings>
 	    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<org.bouncycastle.version>1.46</org.bouncycastle.version>
 		<sonar.jacoco.itReportPath>${project.basedir}/target/jacoco-it.exec</sonar.jacoco.itReportPath>
@@ -124,6 +125,14 @@
 		</pluginManagement>
 
 		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>2.3</version>
+				<configuration>
+					<rulesUri>file:///${project.settings}/version-rules.xml</rulesUri>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>buildnumber-maven-plugin</artifactId>

--- a/settings/version-rules.xml
+++ b/settings/version-rules.xml
@@ -1,0 +1,7 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.3.0.xsd">
+    <ignoreVersions>
+        <ignoreVersion type="regex">.*(alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|‌​RC|M|EA|pr).*</ignoreVersion>
+    </ignoreVersions>
+</ruleset>


### PR DESCRIPTION
via `mvn versions:use-latest-releases`, now with a rules.xml to exclude beta, alpha etc.

fixes #768