### PR TITLE
Added buttons to switch between the list widgets to all tabs except the settings tab

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/MainWindowView.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/MainWindowView.java
@@ -32,7 +32,7 @@ public class MainWindowView<SideBar extends LeftSideBar> extends Tab {
 
     private final BorderPane content;
 
-    private ScrollPane leftContent;
+    private SideBar leftContent;
 
     private HBox waitPanel;
     private FailurePanel failurePanel;
@@ -45,24 +45,12 @@ public class MainWindowView<SideBar extends LeftSideBar> extends Tab {
         this.content = new BorderPane();
         this.content.getStyleClass().add("mainWindowScene");
 
-        this.populateSidebarContainer();
         this.populateFailurePanel();
         this.populateWaitPanel();
 
-        this.content.setLeft(leftContent);
         this.content.setCenter(waitPanel);
 
         this.setContent(content);
-    }
-
-    private void populateSidebarContainer() {
-        this.leftContent = new ScrollPane();
-        this.leftContent.getStyleClass().add("leftPaneScrollbar");
-        this.leftContent.setFitToHeight(true);
-        this.leftContent.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        this.leftContent.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        //this.leftContent.setBorder(Border.EMPTY);
-
     }
 
     private void populateWaitPanel() {
@@ -74,7 +62,8 @@ public class MainWindowView<SideBar extends LeftSideBar> extends Tab {
     }
 
     protected void setSideBar(SideBar sideBar) {
-        this.leftContent.setContent(sideBar);
+        this.leftContent = sideBar;
+        this.content.setLeft(sideBar);
     }
 
     public void setCenter(Node nodeToShow) {

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationSideBar.java
@@ -2,13 +2,9 @@ package org.phoenicis.javafx.views.mainwindow.apps;
 
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
-import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ToggleButton;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.VBox;
 import org.phoenicis.apps.dto.ApplicationDTO;
 import org.phoenicis.apps.dto.CategoryDTO;
 import org.phoenicis.javafx.views.common.widgets.lists.CombinedListWidget;
@@ -38,12 +34,11 @@ import static org.phoenicis.configuration.localisation.Localisation.translate;
  * @since 21.04.17
  */
 public class ApplicationSideBar extends LeftSideBar {
-    private CombinedListWidget<ApplicationDTO> combinedListWidget;
-
-    private BorderPane borderPane;
-
     // the search bar user for application filtering/searching
     private SearchBox searchBar;
+
+    // container for the center content of this sidebar
+    private LeftScrollPane centerContent;
 
     // the toggleable categories
     private LeftToggleGroup<CategoryDTO> categoryView;
@@ -55,6 +50,7 @@ public class ApplicationSideBar extends LeftSideBar {
     private CheckBox noCdNeededCheck;
     private CheckBox commercialCheck;
 
+    // widget to switch between the different list widgets in the center view
     private LeftListWidgetChooser<ApplicationDTO> listWidgetChooser;
 
     // consumers called when an action inside the searchBar has been performed (a filter text was entered or the filter has been cleared)
@@ -65,29 +61,24 @@ public class ApplicationSideBar extends LeftSideBar {
     private Runnable onAllCategorySelection;
     private Consumer<CategoryDTO> onCategorySelection;
 
+    /**
+     * Constructor
+     *
+     * @param combinedListWidget The list widget to be managed by the ListWidgetChooser in the sidebar
+     */
     public ApplicationSideBar(CombinedListWidget<ApplicationDTO> combinedListWidget) {
         super();
-
-        this.combinedListWidget = combinedListWidget;
 
         this.populateSearchBar();
         this.populateCategories();
         this.populateFilters();
-        this.populateListWidgetChooser();
+        this.populateListWidgetChooser(combinedListWidget);
 
-        this.borderPane = new BorderPane();
-        this.borderPane.setPrefHeight(0);
+        this.centerContent = new LeftScrollPane(this.categoryView, new LeftSpacer(), this.filterGroup);
 
-        this.borderPane.setTop(this.searchBar);
-
-        VBox center = new VBox(new LeftSpacer(), this.categoryView, new LeftSpacer(), this.filterGroup);
-
-        this.borderPane.setCenter(center);
-        this.borderPane.setBottom(this.listWidgetChooser);
-
-        this.getChildren().setAll(this.borderPane);
-
-        VBox.setVgrow(borderPane, Priority.ALWAYS);
+        this.setTop(this.searchBar);
+        this.setCenter(this.centerContent);
+        this.setBottom(this.listWidgetChooser);
     }
 
     /**
@@ -123,9 +114,13 @@ public class ApplicationSideBar extends LeftSideBar {
         this.filterGroup = new LeftGroup("Filters", testingCheck, noCdNeededCheck, commercialCheck);
     }
 
-    private void populateListWidgetChooser() {
+    /**
+     * This method populates the list widget choose
+     *
+     * @param combinedListWidget The managed CombinedListWidget
+     */
+    private void populateListWidgetChooser(CombinedListWidget<ApplicationDTO> combinedListWidget) {
         this.listWidgetChooser = new LeftListWidgetChooser<>(combinedListWidget);
-        this.listWidgetChooser.setPadding(new Insets(5));
         this.listWidgetChooser.setAlignment(Pos.BOTTOM_LEFT);
     }
 

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ContainerSideBar.java
@@ -2,8 +2,11 @@ package org.phoenicis.javafx.views.mainwindow.containers;
 
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
+import javafx.geometry.Pos;
 import javafx.scene.control.ToggleButton;
 import org.phoenicis.containers.dto.ContainerCategoryDTO;
+import org.phoenicis.containers.dto.ContainerDTO;
+import org.phoenicis.javafx.views.common.widgets.lists.CombinedListWidget;
 import org.phoenicis.javafx.views.mainwindow.ui.*;
 
 import java.util.function.Consumer;
@@ -30,8 +33,14 @@ public class ContainerSideBar extends LeftSideBar {
     // the search bar used for filtering
     private SearchBox searchBar;
 
+    // container for the center content of this sidebar
+    private LeftScrollPane centerContent;
+
     // a button group containing a button for each installed container
     private LeftToggleGroup<ContainerCategoryDTO> categoryView;
+
+    // widget to switch between the different list widgets in the center view
+    private LeftListWidgetChooser<ContainerDTO> listWidgetChooser;
 
     // consumer called when a search term is entered
     private Consumer<String> onApplyFilter;
@@ -43,14 +52,21 @@ public class ContainerSideBar extends LeftSideBar {
 
     /**
      * Constructor
+     *
+     * @param availableContainers The list widget to be managed by the ListWidgetChooser in the sidebar
      */
-    public ContainerSideBar() {
+    public ContainerSideBar(CombinedListWidget<ContainerDTO> availableContainers) {
         super();
 
         this.populateSearchBar();
         this.populateCategories();
+        this.populateListWidgetChooser(availableContainers);
 
-        this.getChildren().setAll(this.searchBar, new LeftSpacer(), this.categoryView);
+        this.centerContent = new LeftScrollPane(categoryView);
+
+        this.setTop(searchBar);
+        this.setCenter(centerContent);
+        this.setBottom(listWidgetChooser);
     }
 
     /**
@@ -83,6 +99,16 @@ public class ContainerSideBar extends LeftSideBar {
     private void populateCategories() {
         this.categoryView = LeftToggleGroup.create(translate("Containers"), this::createAllCategoriesToggleButton,
                 this::createContainerToggleButton);
+    }
+
+    /**
+     * This method populates the list widget choose
+     *
+     * @param availableContainers The managed CombinedListWidget
+     */
+    private void populateListWidgetChooser(CombinedListWidget<ContainerDTO> availableContainers) {
+        this.listWidgetChooser = new LeftListWidgetChooser<>(availableContainers);
+        this.listWidgetChooser.setAlignment(Pos.BOTTOM_LEFT);
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ViewContainers.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/containers/ViewContainers.java
@@ -51,10 +51,9 @@ public class ViewContainers extends MainWindowView<ContainerSideBar> {
     public ViewContainers(ThemeManager themeManager) {
         super("Containers", themeManager);
 
-        this.sideBar = new ContainerSideBar();
-
         this.availableContainers = new CombinedListWidget<ContainerDTO>(ListWidgetEntry::create,
                 (element, event) -> showContainerDetails(element));
+        this.sideBar = new ContainerSideBar(availableContainers);
 
         this.categories = FXCollections.observableArrayList();
         this.sortedCategories = this.categories.sorted(Comparator.comparing(ContainerCategoryDTO::getName));

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSideBar.java
@@ -2,12 +2,15 @@ package org.phoenicis.javafx.views.mainwindow.engines;
 
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
+import javafx.geometry.Pos;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ToggleButton;
-import javafx.scene.layout.VBox;
 import org.phoenicis.engines.dto.EngineCategoryDTO;
+import org.phoenicis.engines.dto.EngineVersionDTO;
+import org.phoenicis.javafx.views.common.widgets.lists.CombinedListWidget;
 import org.phoenicis.javafx.views.mainwindow.ui.*;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 import static org.phoenicis.configuration.localisation.Localisation.translate;
@@ -35,6 +38,9 @@ public class EngineSideBar extends LeftSideBar {
     // the search bar used for filtering
     private SearchBox searchBar;
 
+    // container for the center content of this sidebar
+    private LeftScrollPane centerContent;
+
     // the button group containing a button for all engine categories
     private LeftToggleGroup<EngineCategoryDTO> categoryView;
 
@@ -43,6 +49,9 @@ public class EngineSideBar extends LeftSideBar {
 
     private CheckBox installedCheck;
     private CheckBox notInstalledCheck;
+
+    // widget to switch between the different list widgets in the center view
+    private LeftListWidgetChooser<EngineVersionDTO> listWidgetChooser;
 
     // consumers called when an action inside the search bar has been performed
     private Consumer<String> onApplySearchTerm;
@@ -57,16 +66,22 @@ public class EngineSideBar extends LeftSideBar {
 
     /**
      * Constructor
+     *
+     * @param enginesVersionListWidgets The list widget to be managed by the ListWidgetChooser in the sidebar
      */
-    public EngineSideBar() {
+    public EngineSideBar(List<CombinedListWidget<EngineVersionDTO>> enginesVersionListWidgets) {
         super();
 
         this.populateSearchBar();
         this.populateEngineCategories();
         this.populateInstallationFilters();
+        this.populateListWidgetChooser(enginesVersionListWidgets);
 
-        this.getChildren().setAll(this.searchBar, new LeftSpacer(), this.categoryView, new LeftSpacer(),
-                this.installationFilterGroup);
+        this.centerContent = new LeftScrollPane(this.categoryView, new LeftSpacer(), this.installationFilterGroup);
+
+        this.setTop(searchBar);
+        this.setCenter(centerContent);
+        this.setBottom(listWidgetChooser);
     }
 
     /**
@@ -108,6 +123,16 @@ public class EngineSideBar extends LeftSideBar {
                 .addListener((observableValue, oldValue, newValue) -> onApplyUninstalledFilter.accept(newValue));
 
         this.installationFilterGroup = new LeftGroup(installedCheck, notInstalledCheck);
+    }
+
+    /**
+     * This method populates the list widget choose
+     *
+     * @param enginesVersionListWidgets The managed CombinedListWidgets
+     */
+    private void populateListWidgetChooser(List<CombinedListWidget<EngineVersionDTO>> enginesVersionListWidgets) {
+        this.listWidgetChooser = new LeftListWidgetChooser<>(enginesVersionListWidgets);
+        this.listWidgetChooser.setAlignment(Pos.BOTTOM_LEFT);
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSubCategoryTab.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/EngineSubCategoryTab.java
@@ -134,4 +134,8 @@ public class EngineSubCategoryTab extends Tab {
         this.enginesFilter.setSearchTerm(searchTerm);
         this.filteredEngineVersions.setPredicate(enginesFilter::test);
     }
+
+    public CombinedListWidget<EngineVersionDTO> getEngineVersionsView() {
+        return engineVersionsView;
+    }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/ViewEngines.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/engines/ViewEngines.java
@@ -29,8 +29,10 @@ import javafx.util.Duration;
 import org.phoenicis.engines.dto.EngineCategoryDTO;
 import org.phoenicis.engines.dto.EngineDTO;
 import org.phoenicis.engines.dto.EngineSubCategoryDTO;
+import org.phoenicis.engines.dto.EngineVersionDTO;
 import org.phoenicis.javafx.views.common.MappedList;
 import org.phoenicis.javafx.views.common.ThemeManager;
+import org.phoenicis.javafx.views.common.widgets.lists.CombinedListWidget;
 import org.phoenicis.javafx.views.mainwindow.MainWindowView;
 
 import java.util.List;
@@ -49,6 +51,7 @@ public class ViewEngines extends MainWindowView<EngineSideBar> {
 
     private ObservableList<EngineSubCategoryDTO> engineSubCategories;
     private MappedList<EngineSubCategoryTab, EngineSubCategoryDTO> mappedSubCategoryTabs;
+    private MappedList<CombinedListWidget<EngineVersionDTO>, EngineSubCategoryTab> mappedListWidgets;
 
     private Consumer<EngineDTO> setOnInstallEngine = (engine) -> {
     };
@@ -60,8 +63,6 @@ public class ViewEngines extends MainWindowView<EngineSideBar> {
     public ViewEngines(ThemeManager themeManager, String enginesPath) {
         super("Engines", themeManager);
 
-        this.sideBar = new EngineSideBar();
-
         this.engineCategories = FXCollections.observableArrayList();
         this.engineSubCategories = FXCollections.observableArrayList();
         this.mappedSubCategoryTabs = new MappedList<>(engineSubCategories, engineSubCategory -> {
@@ -71,6 +72,9 @@ public class ViewEngines extends MainWindowView<EngineSideBar> {
 
             return result;
         });
+        this.mappedListWidgets = new MappedList<>(mappedSubCategoryTabs, tab -> tab.getEngineVersionsView());
+
+        this.sideBar = new EngineSideBar(mappedListWidgets);
 
         this.sideBar.setOnCategorySelection(this::selectCategory);
         this.sideBar.setOnApplyInstalledFilter(newValue -> availableEngines.getTabs()

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibrarySideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/LibrarySideBar.java
@@ -2,8 +2,10 @@ package org.phoenicis.javafx.views.mainwindow.library;
 
 import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
+import javafx.geometry.Pos;
 import javafx.scene.control.ToggleButton;
 import javafx.stage.FileChooser;
+import org.phoenicis.javafx.views.common.widgets.lists.CombinedListWidget;
 import org.phoenicis.javafx.views.mainwindow.ui.*;
 import org.phoenicis.library.dto.ShortcutCategoryDTO;
 import org.phoenicis.library.dto.ShortcutDTO;
@@ -40,6 +42,9 @@ public class LibrarySideBar extends LeftSideBar {
     // the search bar used for filtering
     private SearchBox searchBar;
 
+    // container for the center content of this sidebar
+    private LeftScrollPane centerContent;
+
     // the toggleable categories
     private LeftToggleGroup<ShortcutCategoryDTO> categoryView;
 
@@ -58,6 +63,9 @@ public class LibrarySideBar extends LeftSideBar {
 
     private LeftButton runScript;
     private LeftButton runConsole;
+
+    // widget to switch between the different list widgets in the center view
+    private LeftListWidgetChooser<ShortcutDTO> listWidgetChooser;
 
     // the current selected shortcut
     private ShortcutDTO shortcut;
@@ -78,9 +86,10 @@ public class LibrarySideBar extends LeftSideBar {
     /**
      * Constructor
      *
-     * @param applicationName The name of this application (normally "PlayOnLinux")
+     * @param applicationName    The name of this application (normally "PlayOnLinux")
+     * @param availableShortcuts The list widget to be managed by the ListWidgetChooser in the sidebar
      */
-    public LibrarySideBar(String applicationName) {
+    public LibrarySideBar(String applicationName, CombinedListWidget<ShortcutDTO> availableShortcuts) {
         super();
 
         this.applicationName = applicationName;
@@ -89,8 +98,13 @@ public class LibrarySideBar extends LeftSideBar {
         this.populateShortcut();
         this.populateCategories();
         this.populateAdvancedTools();
+        this.populateListWidgetChooser(availableShortcuts);
 
-        this.hideShortcut();
+        this.centerContent = new LeftScrollPane(this.categoryView, new LeftSpacer(), this.advancedToolsGroup);
+
+        this.setTop(searchBar);
+        this.setCenter(centerContent);
+        this.setBottom(listWidgetChooser);
     }
 
     /**
@@ -113,8 +127,8 @@ public class LibrarySideBar extends LeftSideBar {
 
         this.shortcutGroup.setTitle(shortcut.getName());
 
-        this.getChildren().setAll(this.searchBar, new LeftSpacer(), this.categoryView, this.shortcutGroup,
-                new LeftSpacer(), this.advancedToolsGroup);
+        this.centerContent.setAll(this.categoryView, new LeftSpacer(), this.shortcutGroup, new LeftSpacer(),
+                this.advancedToolsGroup);
     }
 
     /**
@@ -124,7 +138,7 @@ public class LibrarySideBar extends LeftSideBar {
     public void hideShortcut() {
         this.shortcut = null;
 
-        this.getChildren().setAll(this.searchBar, new LeftSpacer(), this.categoryView, this.advancedToolsGroup);
+        this.centerContent.setAll(this.categoryView, new LeftSpacer(), this.advancedToolsGroup);
     }
 
     /**
@@ -147,6 +161,16 @@ public class LibrarySideBar extends LeftSideBar {
     private void populateCategories() {
         this.categoryView = LeftToggleGroup.create(translate("Categories"), this::createAllCategoriesToggleButton,
                 this::createCategoryToggleButton);
+    }
+
+    /**
+     * This method populates the list widget choose
+     *
+     * @param availableShortcuts The managed CombinedListWidget
+     */
+    private void populateListWidgetChooser(CombinedListWidget<ShortcutDTO> availableShortcuts) {
+        this.listWidgetChooser = new LeftListWidgetChooser<>(availableShortcuts);
+        this.listWidgetChooser.setAlignment(Pos.BOTTOM_LEFT);
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/ViewLibrary.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/library/ViewLibrary.java
@@ -106,7 +106,7 @@ public class ViewLibrary extends MainWindowView<LibrarySideBar> {
             event.consume();
         });
 
-        this.sideBar = new LibrarySideBar(applicationName);
+        this.sideBar = new LibrarySideBar(applicationName, availableShortcuts);
         this.sideBar.bindCategories(this.sortedCategories);
 
         this.availableShortcuts.bind(sortedShortcuts);

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/SettingsSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/SettingsSideBar.java
@@ -32,7 +32,7 @@ public class SettingsSideBar extends LeftSideBar {
 
         this.populate();
 
-        this.getChildren().addAll(this.settingsItems);
+        this.setCenter(this.settingsItems);
     }
 
     /**

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftListWidgetChooser.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftListWidgetChooser.java
@@ -6,11 +6,14 @@ import javafx.scene.layout.HBox;
 import org.phoenicis.javafx.views.common.widgets.lists.CombinedListWidget;
 import org.phoenicis.javafx.views.common.widgets.lists.ListWidgetType;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Created by marc on 15.05.17.
  */
 public class LeftListWidgetChooser<E> extends HBox {
-    private CombinedListWidget<E> listWidget;
+    private List<CombinedListWidget<E>> listWidgets;
 
     private ToggleGroup toggleGroup;
 
@@ -19,9 +22,13 @@ public class LeftListWidgetChooser<E> extends HBox {
     private ToggleButton detailsListButton;
 
     public LeftListWidgetChooser(CombinedListWidget<E> listWidget) {
+        this(Arrays.asList(listWidget));
+    }
+
+    public LeftListWidgetChooser(List<CombinedListWidget<E>> listWidgets) {
         super();
 
-        this.listWidget = listWidget;
+        this.listWidgets = listWidgets;
 
         this.getStyleClass().add("listChooser");
 
@@ -30,22 +37,25 @@ public class LeftListWidgetChooser<E> extends HBox {
         this.iconsListButton = new ToggleButton();
         this.iconsListButton.setToggleGroup(toggleGroup);
         this.iconsListButton.getStyleClass().addAll("listIcon", "iconsList");
-        this.iconsListButton.setOnAction(event -> listWidget.showList(ListWidgetType.ICONS_LIST));
+        this.iconsListButton
+                .setOnAction(event -> listWidgets.forEach(widget -> widget.showList(ListWidgetType.ICONS_LIST)));
 
         this.compactListButton = new ToggleButton();
         this.compactListButton.setToggleGroup(toggleGroup);
         this.compactListButton.getStyleClass().addAll("listIcon", "compactList");
-        this.compactListButton.setOnAction(event -> listWidget.showList(ListWidgetType.COMPACT_LIST));
+        this.compactListButton
+                .setOnAction(event -> listWidgets.forEach(widget -> widget.showList(ListWidgetType.COMPACT_LIST)));
 
         this.detailsListButton = new ToggleButton();
         this.detailsListButton.setToggleGroup(toggleGroup);
         this.detailsListButton.getStyleClass().addAll("listIcon", "detailsList");
-        this.detailsListButton.setOnAction(event -> listWidget.showList(ListWidgetType.DETAILS_LIST));
+        this.detailsListButton
+                .setOnAction(event -> listWidgets.forEach(widget -> widget.showList(ListWidgetType.DETAILS_LIST)));
 
         this.iconsListButton.setSelected(true);
 
         this.getChildren().setAll(iconsListButton, compactListButton, detailsListButton);
 
-        this.listWidget.showList(ListWidgetType.ICONS_LIST);
+        this.listWidgets.forEach(widget -> widget.showList(ListWidgetType.ICONS_LIST));
     }
 }

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftScrollPane.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftScrollPane.java
@@ -1,0 +1,40 @@
+package org.phoenicis.javafx.views.mainwindow.ui;
+
+import javafx.scene.Node;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.VBox;
+
+/**
+ * Created by marc on 19.05.17.
+ */
+public class LeftScrollPane extends ScrollPane {
+    private VBox content;
+
+    public LeftScrollPane(Node... nodes) {
+        this();
+
+        this.content.getChildren().setAll(nodes);
+    }
+
+    public LeftScrollPane() {
+        super();
+
+        this.content = new VBox();
+
+        this.setContent(content);
+
+        this.getStyleClass().add("leftPaneScrollbar");
+        this.setFitToHeight(true);
+        this.setFitToWidth(true);
+        this.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        this.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+    }
+
+    public void setAll(Node... nodes) {
+        this.content.getChildren().setAll(nodes);
+    }
+
+    public void addAll(Node... nodes) {
+        this.content.getChildren().addAll(nodes);
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftSideBar.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/ui/LeftSideBar.java
@@ -19,16 +19,19 @@
 package org.phoenicis.javafx.views.mainwindow.ui;
 
 import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.Border;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.VBox;
 
-public abstract class LeftSideBar extends VBox {
+public abstract class LeftSideBar extends BorderPane {
 
     public LeftSideBar() {
         super();
 
         this.getStyleClass().add("leftPane");
+        this.setPrefHeight(0);
     }
 }

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
@@ -293,96 +293,96 @@
     -fx-min-width: 15em;
     -fx-pref-width: 15em;
     -fx-padding: 1em;
-    -fx-spacing: 0.4em;
-}
 
-.leftPaneScrollbar {
-    -fx-border-width: 0;
-    -fx-background-color:@main-color;
-    -fx-min-width: 15em;
-}
+    .leftPaneScrollbar {
+        -fx-border-width: 0;
+        -fx-background-color: @main-color;
+        -fx-min-width: 15em;
+        -fx-padding: 0.8em 1em 0.8em 1em;
+    }
 
-.leftPaneScrollbar > .viewport {
-    -fx-background-color: @main-color;
-}
+    .leftPaneScrollbar > .viewport {
+        -fx-background-color: @main-color;
+    }
 
-.leftPaneScrollbar .scroll-bar:vertical {
-    -fx-max-width: 0.4em;
-    -fx-pref-width: 0.4em;
-}
+    .leftPaneScrollbar .scroll-bar:vertical {
+        -fx-max-width: 0.4em;
+        -fx-pref-width: 0.4em;
+    }
 
-.leftPaneScrollbar .increment-button, .leftPaneScrollbar .decrement-button {
-    -fx-pref-height: 0;
-    -fx-font-size: 0;
-    -fx-opacity: 0;
-}
+    .leftPaneScrollbar .increment-button, .leftPaneScrollbar .decrement-button {
+        -fx-pref-height: 0;
+        -fx-font-size: 0;
+        -fx-opacity: 0;
+    }
 
-.leftPaneScrollbar .scroll-bar:vertical .track {
-    -fx-background-color: #3c3f41;
-    -fx-border-width: 0;
-    -fx-background-radius: 1em;
-    -fx-pref-width: 0.4em;
-    -fx-max-width: 0.4em;
-}
+    .leftPaneScrollbar .scroll-bar:vertical .track {
+        -fx-background-color: #3c3f41;
+        -fx-border-width: 0;
+        -fx-background-radius: 1em;
+        -fx-pref-width: 0.4em;
+        -fx-max-width: 0.4em;
+    }
 
-.leftPaneScrollbar .scroll-bar:vertical .thumb {
-    -fx-background-color:derive(black,70%);
-    -fx-background-insets: 0, 0, 0;
-    -fx-background-radius: 0em;
-    -fx-pref-width: 0.3em;
-    -fx-max-width: 0.3em;
-}
+    .leftPaneScrollbar .scroll-bar:vertical .thumb {
+        -fx-background-color: derive(black, 70%);
+        -fx-background-insets: 0, 0, 0;
+        -fx-background-radius: 0em;
+        -fx-pref-width: 0.3em;
+        -fx-max-width: 0.3em;
+    }
 
-.leftPaneInside {
-    -fx-spacing: 0.4em;
-}
+    .leftPaneInside {
+        -fx-spacing: 0.4em;
+    }
 
-.leftSpacer {
-    -fx-pref-height: 0.8em;
-}
+    .leftSpacer {
+        -fx-pref-height: 0.8em;
+    }
 
-.leftBarTitle {
-    -fx-font-family: "Roboto Regular";
-    -fx-font-size: 1.2em;
-    -fx-alignment: baseline-left;
-    -fx-translate-y: -0.1em;
-    -fx-fill: @inactive-text-color;
-}
+    .leftBarTitle {
+        -fx-font-family: "Roboto Regular";
+        -fx-font-size: 1.2em;
+        -fx-alignment: baseline-left;
+        -fx-translate-y: -0.1em;
+        -fx-fill: @inactive-text-color;
+    }
 
-.leftButton {
-    -fx-background-color:transparent;
-    -fx-cursor: hand;
-    -fx-text-fill: @text-color;
-    -fx-txt-font-family: "Roboto Light";
-    -fx-label-padding: 0.2em 0 0.2em 2.2em;
-    -fx-background-size: 2em;
-    -fx-background-repeat: no-repeat;
-    -fx-background-position: left;
-}
+    .leftButton {
+        -fx-background-color: transparent;
+        -fx-cursor: hand;
+        -fx-text-fill: @text-color;
+        -fx-txt-font-family: "Roboto Light";
+        -fx-label-padding: 0.2em 0 0.2em 2.2em;
+        -fx-background-size: 2em;
+        -fx-background-repeat: no-repeat;
+        -fx-background-position: left;
+    }
 
-.leftButton:hover, .leftButton:selected {
-    -fx-background-color: @focus-color;
-    -fx-background-insets: 0, 1, 2;
-    -fx-background-radius: 0;
-}
+    .leftButton:hover, .leftButton:selected {
+        -fx-background-color: @focus-color;
+        -fx-background-insets: 0, 1, 2;
+        -fx-background-radius: 0;
+    }
 
-.searchBar {
-    -fx-border-radius: 0;
-    -fx-background-radius: 0;
-    -fx-background-color: @background-color;
-    -fx-border-color: transparent;
-    -fx-text-fill: @text-color;
-    -fx-focus-color: @focus-color;
-}
+    .searchBar {
+        -fx-border-radius: 0;
+        -fx-background-radius: 0;
+        -fx-background-color: @background-color;
+        -fx-border-color: transparent;
+        -fx-text-fill: @text-color;
+        -fx-focus-color: @focus-color;
+    }
 
-.searchBar:hover {
-    -fx-border-color: @focus-color;
-    -fx-text-fill: @text-color;
-}
+    .searchBar:hover {
+        -fx-border-color: @focus-color;
+        -fx-text-fill: @text-color;
+    }
 
-.searchCleanButton {
-	-fx-background-color: transparent;
-	-fx-graphic: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/general/edit-clear.png');
+    .searchCleanButton {
+        -fx-background-color: transparent;
+        -fx-graphic: url('/org/phoenicis/javafx/themes/breezeDark/icons/mainwindow/general/edit-clear.png');
+    }
 }
 
 /*******************************************************/

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/dark/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/dark/main.less
@@ -104,86 +104,86 @@
     -fx-min-width: 15em;
     -fx-pref-width: 15em;
     -fx-padding: 1em;
-    -fx-spacing: 0.4em;
-}
 
-.leftPaneScrollbar {
-    -fx-border-width: 0;
-    -fx-background-color: @background-color;
-    -fx-min-width: 15em;
-}
+    .leftPaneScrollbar {
+        -fx-border-width: 0;
+        -fx-background-color: @background-color;
+        -fx-min-width: 15em;
+        -fx-padding: 0.8em 1em 0.8em 1em;
+    }
 
-.leftPaneScrollbar > .viewport {
-    -fx-background-color: @background-color;
-}
+    .leftPaneScrollbar > .viewport {
+        -fx-background-color: @background-color;
+    }
 
-.leftPaneScrollbar .scroll-bar:vertical {
-    -fx-max-width: 0.4em;
-    -fx-pref-width: 0.4em;
-}
+    .leftPaneScrollbar .scroll-bar:vertical {
+        -fx-max-width: 0.4em;
+        -fx-pref-width: 0.4em;
+    }
 
-.leftPaneScrollbar .increment-button, .leftPaneScrollbar .decrement-button {
-    -fx-pref-height: 0;
-    -fx-font-size: 0;
-    -fx-opacity: 0;
-}
+    .leftPaneScrollbar .increment-button, .leftPaneScrollbar .decrement-button {
+        -fx-pref-height: 0;
+        -fx-font-size: 0;
+        -fx-opacity: 0;
+    }
 
-.leftPaneScrollbar .scroll-bar:vertical .track {
-    -fx-background-color: @background-color;
-    -fx-border-width: 0;
-    -fx-background-radius: 1em;
-    -fx-pref-width: 0.4em;
-    -fx-max-width: 0.4em;
-}
+    .leftPaneScrollbar .scroll-bar:vertical .track {
+        -fx-background-color: @background-color;
+        -fx-border-width: 0;
+        -fx-background-radius: 1em;
+        -fx-pref-width: 0.4em;
+        -fx-max-width: 0.4em;
+    }
 
-.leftPaneScrollbar .scroll-bar:vertical .thumb {
-    -fx-background-color:derive(black,70%);
-    -fx-background-insets: 0, 0, 0;
-    -fx-background-radius: 0em;
-    -fx-pref-width: 0.3em;
-    -fx-max-width: 0.3em;
-}
+    .leftPaneScrollbar .scroll-bar:vertical .thumb {
+        -fx-background-color: derive(black, 70%);
+        -fx-background-insets: 0, 0, 0;
+        -fx-background-radius: 0em;
+        -fx-pref-width: 0.3em;
+        -fx-max-width: 0.3em;
+    }
 
-.leftPaneInside {
-    -fx-spacing: 0.4em;
-}
+    .leftPaneInside {
+        -fx-spacing: 0.4em;
+    }
 
-.leftSpacer {
-    -fx-pref-height: 0.8em;
-}
+    .leftSpacer {
+        -fx-pref-height: 0.8em;
+    }
 
-.leftBarTitle {
-    -fx-font-family: "Roboto Regular";
-    -fx-font-size: 1.1em;
-    -fx-alignment: baseline-left;
-    -fx-translate-y: -0.1em;
-    -fx-text-fill: @text-color;
-}
+    .leftBarTitle {
+        -fx-font-family: "Roboto Regular";
+        -fx-font-size: 1.1em;
+        -fx-alignment: baseline-left;
+        -fx-translate-y: -0.1em;
+        -fx-text-fill: @text-color;
+    }
 
-.leftButton {
-    -fx-background-color:transparent;
-    -fx-cursor: hand;
-    -fx-text-fill: @text-color;
-    -fx-txt-font-family: "Roboto Light";
-    -fx-label-padding: 0.2em 0 0.2em 2.2em;
-    -fx-background-size: 2em;
-    -fx-background-repeat: no-repeat;
-    -fx-background-position: left;
-}
+    .leftButton {
+        -fx-background-color: transparent;
+        -fx-cursor: hand;
+        -fx-text-fill: @text-color;
+        -fx-txt-font-family: "Roboto Light";
+        -fx-label-padding: 0.2em 0 0.2em 2.2em;
+        -fx-background-size: 2em;
+        -fx-background-repeat: no-repeat;
+        -fx-background-position: left;
+    }
 
-.leftButton:hover, .leftButton:selected {
-    -fx-background-color: #9f9da6;
-    -fx-background-insets: 0, 1, 2;
-    -fx-background-radius: 3, 2, 1;
-}
+    .leftButton:hover, .leftButton:selected {
+        -fx-background-color: #9f9da6;
+        -fx-background-insets: 0, 1, 2;
+        -fx-background-radius: 3, 2, 1;
+    }
 
-.leftPaneCheckBox .text {
-    -fx-fill: @text-color;
-}
+    .leftPaneCheckBox .text {
+        -fx-fill: @text-color;
+    }
 
-.searchCleanButton {
-	-fx-background-color: transparent;
-	-fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/edit-clear.png');
+    .searchCleanButton {
+        -fx-background-color: transparent;
+        -fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/edit-clear.png');
+    }
 }
 
 /*******************************************************/

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
@@ -22,502 +22,503 @@
 /*********************** general ***********************/
 /*******************************************************/
 .text-field {
-    -fx-background-radius: 1em;
+  -fx-background-radius: 1em;
 }
 
 /*******************************************************/
 /****************** main window scene ******************/
 /*******************************************************/
 .mainWindowScene {
-    -fx-min-height: 35.2em;
-    -fx-fit-to-height: true;
+  -fx-min-height: 35.2em;
+  -fx-fit-to-height: true;
 }
 
 /*******************************************************/
 /************************ logo *************************/
 /*******************************************************/
 #logo {
-    -fx-background-image: url('/org/phoenicis/javafx/views/common/phoenicis.png');
-    -fx-background-size: contain;
-    -fx-background-repeat: no-repeat;
-    -fx-background-position: left center;
+  -fx-background-image: url('/org/phoenicis/javafx/views/common/phoenicis.png');
+  -fx-background-size: contain;
+  -fx-background-repeat: no-repeat;
+  -fx-background-position: left center;
 }
 
 #logoText {
-    -fx-vpos: center;
-    -fx-font-family: "Maven Pro";
-    -fx-font-size: 1.8em;
-    -fx-text-fill: #ffffff;
+  -fx-vpos: center;
+  -fx-font-family: "Maven Pro";
+  -fx-font-size: 1.8em;
+  -fx-text-fill: #ffffff;
 }
 
 /*******************************************************/
 /************************ menu *************************/
 /*******************************************************/
 #menuPane {
-    -fx-tab-min-width: 7em;
-    -fx-padding: -0.9 0 0 0;
-    -fx-spacing: 0;
-    -fx-pref-height: 43.3em;
+  -fx-tab-min-width: 7em;
+  -fx-padding: -0.9 0 0 0;
+  -fx-spacing: 0;
+  -fx-pref-height: 43.3em;
 }
 
 #menuPane > .tab-header-area .tab {
-    -fx-border-width: 0.3em;
-    -fx-border-color: transparent;
-    -fx-border-style: hidden hidden solid hidden;
-    -fx-background-color: transparent;
-    -fx-background-opacity: 0;
-    -fx-pref-height: 3.5em;
+  -fx-border-width: 0.3em;
+  -fx-border-color: transparent;
+  -fx-border-style: hidden hidden solid hidden;
+  -fx-background-color: transparent;
+  -fx-background-opacity: 0;
+  -fx-pref-height: 3.5em;
 }
 
 #menuPane > .tab-header-area .tab-label {
-    -fx-alignment: CENTER;
-    -fx-padding: 0 0 -0.4em 0;
-    -fx-text-font-family: "Roboto Light";
-    -fx-text-fill: #FFFFFF;
-    -fx-font-size: 1.2em;
-    -fx-cursor: hand;
+  -fx-alignment: CENTER;
+  -fx-padding: 0 0 -0.4em 0;
+  -fx-text-font-family: "Roboto Light";
+  -fx-text-fill: #FFFFFF;
+  -fx-font-size: 1.2em;
+  -fx-cursor: hand;
 }
 
 #menuPane > .tab-header-area .tab-header-background {
-    -fx-background-color: linear-gradient(#428bca, #116395);
-    -fx-min-height: 2.5em;
-    -fx-max-height: 2.5em;
+  -fx-background-color: linear-gradient(#428bca, #116395);
+  -fx-min-height: 2.5em;
+  -fx-max-height: 2.5em;
 }
 
 #menuPane > .tab-header-area .tab:selected {
-    -fx-border-width: 0.3em;
-    -fx-border-style: hidden hidden solid hidden;
-    -fx-border-color: #529bda;
-    -fx-focus-color: transparent;
-    -fx-faint-focus-color: transparent;
+  -fx-border-width: 0.3em;
+  -fx-border-style: hidden hidden solid hidden;
+  -fx-border-color: #529bda;
+  -fx-focus-color: transparent;
+  -fx-faint-focus-color: transparent;
 }
 
 #menuPane > .tab-header-area .tab:disabled {
-    -fx-opacity: 1;
+  -fx-opacity: 1;
 }
 
 /*******************************************************/
 /************************* left ************************/
 /*******************************************************/
 .leftPane {
-    -fx-background-color: @background-color;
-    -fx-min-height: 10em;
-    -fx-min-width: 15em;
-    -fx-pref-width: 15em;
-    -fx-spacing: 0.4em;
-    -fx-padding: 1em;
-}
+  -fx-background-color: @background-color;
+  -fx-min-height: 10em;
+  -fx-min-width: 15em;
+  -fx-pref-width: 15em;
+  -fx-padding: 1em;
 
-.leftPaneScrollbar {
+  .leftPaneScrollbar {
     -fx-border-width: 0;
-    -fx-background-color:@background-color;
-    -fx-min-width: 15em;
-}
-
-.leftPaneScrollbar > .viewport {
     -fx-background-color: @background-color;
-}
+    -fx-min-width: 15em;
+    -fx-padding: 0.8em 1em 0.8em 1em;
+  }
 
-.leftPaneScrollbar .scroll-bar:vertical {
+  .leftPaneScrollbar > .viewport {
+    -fx-background-color: @background-color;
+  }
+
+  .leftPaneScrollbar .scroll-bar:vertical {
     -fx-max-width: 0.4em;
     -fx-pref-width: 0.4em;
-}
+  }
 
-.leftPaneScrollbar .increment-button, .leftPaneScrollbar .decrement-button {
+  .leftPaneScrollbar .increment-button, .leftPaneScrollbar .decrement-button {
     -fx-pref-height: 0;
     -fx-font-size: 0;
     -fx-opacity: 0;
-}
+  }
 
-.leftPaneScrollbar .scroll-bar:vertical .track {
+  .leftPaneScrollbar .scroll-bar:vertical .track {
     -fx-background-color: @background-color;
     -fx-border-width: 0;
     -fx-background-radius: 0em;
     -fx-pref-width: 0.4em;
     -fx-max-width: 0.4em;
-}
+  }
 
-.leftPaneScrollbar .scroll-bar:vertical .thumb {
-    -fx-background-color:derive(black,90%);
+  .leftPaneScrollbar .scroll-bar:vertical .thumb {
+    -fx-background-color: derive(black, 90%);
     -fx-background-insets: 0, 0, 0;
     -fx-background-radius: 1em;
     -fx-pref-width: 0.3em;
     -fx-max-width: 0.3em;
-}
+  }
 
-.leftPaneInside {
+  .leftPaneInside {
     -fx-spacing: 0.4em;
-}
+  }
 
-.leftSpacer {
+  .leftSpacer {
     -fx-pref-height: 0.8em;
-}
+  }
 
-.leftBarTitle {
+  .leftBarTitle {
     -fx-font-family: "Roboto Regular";
     -fx-font-size: 1.1em;
     -fx-alignment: baseline-left;
     -fx-translate-y: -0.1em;
-}
+  }
 
-.leftButton {
-    -fx-background-color:transparent;
+  .leftButton {
+    -fx-background-color: transparent;
     -fx-cursor: hand;
     -fx-txt-font-family: "Roboto Light";
     -fx-label-padding: 0.2em 0 0.2em 2.2em;
     -fx-background-size: 2em;
     -fx-background-repeat: no-repeat;
     -fx-background-position: left;
-}
+  }
 
-.leftButton:hover, .leftButton:selected {
+  .leftButton:hover, .leftButton:selected {
     -fx-background-color: #D3D3D3;
     -fx-background-insets: 0, 1, 2;
     -fx-background-radius: 3, 2, 1;
-}
+  }
 
-.searchCleanButton {
-	-fx-background-color: transparent;
-	-fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/edit-clear.png');
+  .searchCleanButton {
+    -fx-background-color: transparent;
+    -fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/edit-clear.png');
+  }
 }
 
 /*******************************************************/
 /************************ right ************************/
 /*******************************************************/
 .rightPane {
-    -fx-pref-width: 55em;
-    -fx-border-width: 0;
-    -fx-border-style: none;
-    -fx-focus-traversable: false;
-    -fx-background-color: transparent;
+  -fx-pref-width: 55em;
+  -fx-border-width: 0;
+  -fx-border-style: none;
+  -fx-focus-traversable: false;
+  -fx-background-color: transparent;
 
 }
 
 .rightPane > .viewport {
-    -fx-background-color: #FFFFFF;
-    -fx-border-width: 0;
+  -fx-background-color: #FFFFFF;
+  -fx-border-width: 0;
 }
 
 .retryButton {
-    -fx-label-padding: 0.2em 0 0.2em 0.5em;
-    -fx-background-size: 1.3em;
-    -fx-background-repeat: no-repeat;
-    -fx-background-position: left;
+  -fx-label-padding: 0.2em 0 0.2em 0.5em;
+  -fx-background-size: 1.3em;
+  -fx-background-repeat: no-repeat;
+  -fx-background-position: left;
 }
 
 /*******************************************************/
 /************************* apps ************************/
 /*******************************************************/
 .appPresentation {
-    -fx-background-color: #FFFFFF;
+  -fx-background-color: #FFFFFF;
 }
 
 .appPresentation > * {
-    -fx-padding: 0.5em;
-    -fx-spacing: 0.5em;
+  -fx-padding: 0.5em;
+  -fx-spacing: 0.5em;
 }
 
 .appPanelMiniaturesPane {
-    -fx-background-color: #FAFAFA;
-    -fx-padding: 0.5em;
+  -fx-background-color: #FAFAFA;
+  -fx-padding: 0.5em;
 }
 
 .appMiniature {
-    -fx-background-size: contain;
-    -fx-background-repeat: no-repeat;
-    -fx-background-position: left center;
+  -fx-background-size: contain;
+  -fx-background-repeat: no-repeat;
+  -fx-background-position: left center;
 }
 
 .appPanelMiniaturesPaneWrapper {
-    -fx-padding: 0;
-    -fx-border-width: 0;
-    -fx-border-style: none;
-    -fx-focus-traversable: false;
-    -fx-background-color: transparent;
-    -fx-min-height: 12em;
+  -fx-padding: 0;
+  -fx-border-width: 0;
+  -fx-border-style: none;
+  -fx-focus-traversable: false;
+  -fx-background-color: transparent;
+  -fx-min-height: 12em;
 }
 
 .appPanelMiniaturesPaneWrapper > .viewport {
-    -fx-background-color: #FAFAFA;
-    -fx-border-width: 0;
+  -fx-background-color: #FAFAFA;
+  -fx-border-width: 0;
 }
 
 /********************** description ********************/
 .descriptionTitle {
-    -fx-font-family: "Roboto light";
-    -fx-text-fill: #428bca;
-    -fx-font-size: 16;
+  -fx-font-family: "Roboto light";
+  -fx-text-fill: #428bca;
+  -fx-font-size: 16;
 }
 
 /*******************************************************/
 /********************** containers *********************/
 /*******************************************************/
 .containerConfigurationPane {
-    -fx-padding: 1em;
+  -fx-padding: 1em;
 }
 
 .containerConfigurationPane > .grid {
-    -fx-padding: 1em;
-    -fx-hgap: 1em;
-    -fx-vgap: 1em;
-    -fx-spacing: 1em;
+  -fx-padding: 1em;
+  -fx-hgap: 1em;
+  -fx-vgap: 1em;
+  -fx-spacing: 1em;
 }
 
 /*******************************************************/
 /********************** miniature **********************/
 /*******************************************************/
 .rightPane .miniatureList {
-    -fx-pref-width: 53.5em;
-    -fx-background-color: #FFFFFF;
-    -fx-border-width: 0;
-    -fx-border-style: none;
-    -fx-padding: 0.5em;
+  -fx-pref-width: 53.5em;
+  -fx-background-color: #FFFFFF;
+  -fx-border-width: 0;
+  -fx-border-style: none;
+  -fx-padding: 0.5em;
 }
 
 .miniatureListElement {
-    -fx-pref-width: 12em;
-    -fx-pref-height: 9em;
-    -fx-font-family: "Roboto Light";
-    -fx-alignment: top-center;
-    -fx-spacing: 0.3em;
-    -fx-padding: 0.5em;
-    -fx-cursor: hand;
-    -fx-background-radius: 0.8em;
+  -fx-pref-width: 12em;
+  -fx-pref-height: 9em;
+  -fx-font-family: "Roboto Light";
+  -fx-alignment: top-center;
+  -fx-spacing: 0.3em;
+  -fx-padding: 0.5em;
+  -fx-cursor: hand;
+  -fx-background-radius: 0.8em;
 }
 
 .miniatureListElement:hover {
-    -fx-background-color: #EFEFEF;
+  -fx-background-color: #EFEFEF;
 }
 
 .miniatureListElement.selected {
-    -fx-background-color: #EAEAEA;
+  -fx-background-color: #EAEAEA;
 }
 
 .miniatureImage {
-    -fx-border-radius: 0.4em;
-    -fx-background-radius: 0.4em;
-    -fx-background-size: contain;
-    -fx-background-repeat: no-repeat;
-    -fx-background-position: center;
-    -fx-pref-width: 15em;
-    -fx-pref-height: 12em;
+  -fx-border-radius: 0.4em;
+  -fx-background-radius: 0.4em;
+  -fx-background-size: contain;
+  -fx-background-repeat: no-repeat;
+  -fx-background-position: center;
+  -fx-pref-width: 15em;
+  -fx-pref-height: 12em;
 }
 
 .miniatureText {
-    -fx-font-size: 0.90em;
-    -fx-wrap-text: true;
-    -fx-alignment: center;
-    -fx-text-alignment: center;
+  -fx-font-size: 0.90em;
+  -fx-wrap-text: true;
+  -fx-alignment: center;
+  -fx-text-alignment: center;
 }
 
 .compactListWidget {
-    -fx-border-width: 0;
-    -fx-border-style: none;
+  -fx-border-width: 0;
+  -fx-border-style: none;
 
-    .iconListCell {
-        @cellHeight: 6em;
+  .iconListCell {
+    @cellHeight: 6em;
 
-        -fx-hgap: 0.5em;
-        -fx-pref-height: @cellHeight;
+    -fx-hgap: 0.5em;
+    -fx-pref-height: @cellHeight;
 
-        .iconListMiniatureImage {
-            @miniatureWidth: 8em;
+    .iconListMiniatureImage {
+      @miniatureWidth: 8em;
 
-            -fx-background-size: stretch;
-            -fx-background-repeat: no-repeat;
-            -fx-background-position: center;
-            -fx-min-width: @miniatureWidth;
-            -fx-pref-width: @miniatureWidth;
-            -fx-max-width: @miniatureWidth;
-            -fx-min-height: @cellHeight;
-            -fx-pref-height: @cellHeight;
-            -fx-max-height: @cellHeight;
-        }
-
-        .information {
-            -fx-max-height: @cellHeight;
-        }
+      -fx-background-size: stretch;
+      -fx-background-repeat: no-repeat;
+      -fx-background-position: center;
+      -fx-min-width: @miniatureWidth;
+      -fx-pref-width: @miniatureWidth;
+      -fx-max-width: @miniatureWidth;
+      -fx-min-height: @cellHeight;
+      -fx-pref-height: @cellHeight;
+      -fx-max-height: @cellHeight;
     }
+
+    .information {
+      -fx-max-height: @cellHeight;
+    }
+  }
 }
 
 .detailsListWidget {
-    -fx-border-width: 0;
-    -fx-border-style: none;
+  -fx-border-width: 0;
+  -fx-border-style: none;
 
-    .iconListCell {
-        -fx-hgap: 0.5em;
+  .iconListCell {
+    -fx-hgap: 0.5em;
 
-        .information {
-            -fx-max-height: 3em;
-        }
+    .information {
+      -fx-max-height: 3em;
     }
+  }
 }
 
 .listChooser {
-    -fx-spacing: 0.1em;
-    -fx-padding: 0;
+  -fx-spacing: 0.1em;
+  -fx-padding: 0;
 
-    .listIcon {
-        -fx-pref-width: 2.5em;
-        -fx-pref-height: 2.5em;
-        -fx-content-display: graphic-only;
-        -fx-background-size: contain;
-        -fx-background-repeat: no-repeat;
-        -fx-background-position: center;
-    }
+  .listIcon {
+    -fx-pref-width: 2.5em;
+    -fx-pref-height: 2.5em;
+    -fx-content-display: graphic-only;
+    -fx-background-size: contain;
+    -fx-background-repeat: no-repeat;
+    -fx-background-position: center;
+  }
 
-    .listIcon:selected {
-        -fx-border-radius: 0.25em;
-        -fx-border-color: blue;
-    }
+  .listIcon:selected {
+    -fx-border-radius: 0.25em;
+    -fx-border-color: blue;
+  }
 
-    .compactList {
-        -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/view-list-compact-symbolic.png');
-    }
+  .compactList {
+    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/view-list-compact-symbolic.png');
+  }
 
-    .detailsList {
-        -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/view-list-details-symbolic.png');
-    }
+  .detailsList {
+    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/view-list-details-symbolic.png');
+  }
 
-    .iconsList {
-        -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/view-list-icons-symbolic.png');
-    }
+  .iconsList {
+    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/view-list-icons-symbolic.png');
+  }
 }
 
 /*******************************************************/
 /***************** installation wizard *****************/
 /*******************************************************/
 #presentationBackground {
-    -fx-background-color: white;
-    -fx-padding: 1em;
+  -fx-background-color: white;
+  -fx-padding: 1em;
 }
 
 #presentationScrollPane {
-    -fx-background: white;
-    -fx-border-color: white;
+  -fx-background: white;
+  -fx-border-color: white;
 }
 
 #presentationTextTitle {
-    -fx-font-weight: bold;
-    -fx-fill: black;
-    -fx-font-size: 1.3em;
+  -fx-font-weight: bold;
+  -fx-fill: black;
+  -fx-font-size: 1.3em;
 }
 
 #presentationText {
-    -fx-fill: black;
+  -fx-fill: black;
 }
 
 /************************ step *************************/
 #panelForTopheader {
-    -fx-padding: 2.5em;
-    -fx-background-color: #F4F4F4;
+  -fx-padding: 2.5em;
+  -fx-background-color: #F4F4F4;
 }
 
 #header {
-    -fx-border-color: #CCCCCC;
-    -fx-border-style: solid;
-    -fx-border-width: 0 0 0.1em 0;
-    -fx-background-color: #FFFFFF;
+  -fx-border-color: #CCCCCC;
+  -fx-border-style: solid;
+  -fx-border-width: 0 0 0.1em 0;
+  -fx-background-color: #FFFFFF;
 }
 
 #footer {
-    -fx-border-color: #CCCCCC;
-    -fx-border-style: solid;
-    -fx-border-width: 0.1em 0 0 0;
+  -fx-border-color: #CCCCCC;
+  -fx-border-style: solid;
+  -fx-border-width: 0.1em 0 0 0;
 }
 
 #stepScrollPane {
-    -fx-background: #F4F4F4;
-    -fx-border-color: #F4F4F4;
+  -fx-background: #F4F4F4;
+  -fx-border-color: #F4F4F4;
 }
 
 .dragAndDropBox {
-    -fx-background-color: #F6F6F6;
-    -fx-text-alignment: center;
-    -fx-alignment: center;
-    -fx-border-style: dashed;
-    -fx-border-color: #CCC;
-    -fx-border-width: 0.5em;
+  -fx-background-color: #F6F6F6;
+  -fx-text-alignment: center;
+  -fx-alignment: center;
+  -fx-border-style: dashed;
+  -fx-border-color: #CCC;
+  -fx-border-width: 0.5em;
 }
 
 /*******************************************************/
 /*********************** console ***********************/
 /*******************************************************/
 .console {
-    -fx-pref-width: 60em;
-    -fx-padding: 0.5em;
-    -fx-font-family: "Lucida Console";
+  -fx-pref-width: 60em;
+  -fx-padding: 0.5em;
+  -fx-font-family: "Lucida Console";
 }
 
 .console, .console .viewport {
-    -fx-background-color: #FFFFFF;
+  -fx-background-color: #FFFFFF;
 }
 
 .consoleCommandType {
-    -fx-border-radius: 0;
-    -fx-background-color: #FFF;
-    -fx-background-insets: 0, 1, 2;
-    -fx-background-radius: 0;
-    -fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);
+  -fx-border-radius: 0;
+  -fx-background-color: #FFF;
+  -fx-background-insets: 0, 1, 2;
+  -fx-background-radius: 0;
+  -fx-prompt-text-fill: derive(-fx-control-inner-background, -30%);
 }
 
 .consoleText.normal {
-    -fx-fill: black;
+  -fx-fill: black;
 }
 
 .consoleText.default {
-    -fx-fill: #999999;
+  -fx-fill: #999999;
 }
 
 .consoleText.error {
-    -fx-fill: #cc0000;
+  -fx-fill: #cc0000;
 }
 
 /*******************************************************/
 /********************** wine tools *********************/
 /*******************************************************/
 .wineToolButton {
-    -fx-pref-width: 8em;
-    -fx-pref-height: 8em;
-    -fx-content-display: graphic-only;
-    -fx-background-size: 4em;
-    -fx-background-repeat: no-repeat;
-    -fx-background-position: center;
+  -fx-pref-width: 8em;
+  -fx-pref-height: 8em;
+  -fx-content-display: graphic-only;
+  -fx-background-size: 4em;
+  -fx-background-repeat: no-repeat;
+  -fx-background-position: center;
 }
 
 .wineToolCaption {
-    -fx-font-size: 0.85em;
-    -fx-pref-width: 8em;
+  -fx-font-size: 0.85em;
+  -fx-pref-width: 8em;
 }
 
 /*******************************************************/
 /************************* misc ************************/
 /*******************************************************/
 .title {
-    -fx-font-family: "Roboto Regular";
-    -fx-font-size: 1.4em;
-    -fx-alignment: baseline-left;
-    -fx-translate-y: -0.1em;
-    -fx-fill: #428bca;
+  -fx-font-family: "Roboto Regular";
+  -fx-font-size: 1.4em;
+  -fx-alignment: baseline-left;
+  -fx-translate-y: -0.1em;
+  -fx-fill: #428bca;
 }
 
 .captionTitle {
-    -fx-font-weight: normal;
+  -fx-font-weight: normal;
 }
 
 .boldLabel {
-    -fx-font-family: "Roboto Bold";
+  -fx-font-family: "Roboto Bold";
 }
+
 .normalLabel {
-    -fx-font-family: "Roboto Light";
+  -fx-font-family: "Roboto Light";
 }
 
 .buttonWithIcon {
-    -fx-background-color:transparent;
-    -fx-label-padding: 0.2em 0 0.2em 2.2em;
-    -fx-background-size: 2em;
-    -fx-background-repeat: no-repeat;
-    -fx-background-position: left;
+  -fx-background-color: transparent;
+  -fx-label-padding: 0.2em 0 0.2em 2.2em;
+  -fx-background-size: 2em;
+  -fx-background-repeat: no-repeat;
+  -fx-background-position: left;
 }
 
 /*******************************************************/
@@ -525,62 +526,62 @@
 /*******************************************************/
 /************************ util *************************/
 .refreshIcon {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/refresh.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/refresh.png');
 }
 
 /************************ apps *************************/
 #allButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/apps/all.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/apps/all.png');
 }
 
 /********************* containers **********************/
 .containerButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/containers/container.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/containers/container.png');
 }
 
 /*********************** engines ***********************/
 #wineButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/engines/wine.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/engines/wine.png');
 }
 
 /*********************** library ***********************/
 .runButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/library/play.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/library/play.png');
 }
 
 .stopButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/library/stop.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/library/stop.png');
 }
 
 .uninstallButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/library/remove.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/library/remove.png');
 }
 
 .scriptButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/library/script.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/library/script.png');
 }
 
 .consoleButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/library/console.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/library/console.png');
 }
 
 /*********************** settings **********************/
 .userInterfaceButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/settings/userInterface.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/settings/userInterface.png');
 }
 
 .repositoriesButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/settings/repository.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/settings/repository.png');
 }
 
 .settingsButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/settings/settings.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/settings/settings.png');
 }
 
 .networkButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/settings/network.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/settings/network.png');
 }
 
 .aboutButton {
-    -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/settings/about.png');
+  -fx-background-image: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/settings/about.png');
 }

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
@@ -323,111 +323,110 @@
     -fx-min-width: 15em;
     -fx-pref-width: 15em;
     -fx-padding: 0 0 0.83em 0;
-    -fx-spacing: 0.4em;
-}
 
-.leftPaneScrollbar {
-    -fx-border-width: 0;
-    -fx-background-color:@main-color;
-    -fx-min-width: 15em;
-}
+    .leftPaneScrollbar {
+        -fx-border-width: 0;
+        -fx-background-color: @main-color;
+        -fx-min-width: 15em;
+    }
 
-.leftPaneScrollbar > .viewport {
-    -fx-background-color: @main-color;
-}
+    .leftPaneScrollbar > .viewport {
+        -fx-background-color: @main-color;
+    }
 
-.leftPaneScrollbar .scroll-bar:vertical {
-    -fx-max-width: 0.4em;
-    -fx-pref-width: 0.4em;
-}
+    .leftPaneScrollbar .scroll-bar:vertical {
+        -fx-max-width: 0.4em;
+        -fx-pref-width: 0.4em;
+    }
 
-.leftPaneScrollbar .increment-button, .leftPaneScrollbar .decrement-button {
-    -fx-pref-height: 0;
-    -fx-font-size: 0;
-    -fx-opacity: 0;
-}
+    .leftPaneScrollbar .increment-button, .leftPaneScrollbar .decrement-button {
+        -fx-pref-height: 0;
+        -fx-font-size: 0;
+        -fx-opacity: 0;
+    }
 
-.leftPaneScrollbar .scroll-bar:vertical .track {
-    -fx-background-color: #3c3f41;
-    -fx-border-width: 0;
-    -fx-background-radius: 1em;
-    -fx-pref-width: 0.4em;
-    -fx-max-width: 0.4em;
-}
+    .leftPaneScrollbar .scroll-bar:vertical .track {
+        -fx-background-color: #3c3f41;
+        -fx-border-width: 0;
+        -fx-background-radius: 1em;
+        -fx-pref-width: 0.4em;
+        -fx-max-width: 0.4em;
+    }
 
-.leftPaneScrollbar .scroll-bar:vertical .thumb {
-    -fx-background-color:derive(black,70%);
-    -fx-background-insets: 0, 0, 0;
-    -fx-background-radius: 0em;
-    -fx-pref-width: 0.3em;
-    -fx-max-width: 0.3em;
-}
+    .leftPaneScrollbar .scroll-bar:vertical .thumb {
+        -fx-background-color: derive(black, 70%);
+        -fx-background-insets: 0, 0, 0;
+        -fx-background-radius: 0em;
+        -fx-pref-width: 0.3em;
+        -fx-max-width: 0.3em;
+    }
 
-.leftPaneInside {
-    -fx-spacing: 0.4em;
-}
+    .leftPaneInside {
+        -fx-spacing: 0.4em;
+    }
 
-.leftSpacer {
-    -fx-pref-height: 0;
-}
+    .leftSpacer {
+        -fx-pref-height: 0;
+    }
 
-.leftBarTitle {
-    -fx-padding: 0.83em 0.83em 0.4em 0.83em;
-    -fx-font-family: "Roboto Regular";
-    -fx-font-size: 1.2em;
-    -fx-alignment: baseline-left;
-    -fx-fill: #3c3b37;
-}
+    .leftBarTitle {
+        -fx-padding: 0.83em 0.83em 0.4em 0.83em;
+        -fx-font-family: "Roboto Regular";
+        -fx-font-size: 1.2em;
+        -fx-alignment: baseline-left;
+        -fx-fill: #3c3b37;
+    }
 
-.leftButton {
-    -fx-padding: 0 0.83em 0 0.83em;
-    -fx-background-color:transparent;
-    -fx-border-color:transparent;
-    -fx-cursor: hand;
-    -fx-text-fill: @text-color;
-    -fx-txt-font-family: "Roboto Light";
-    -fx-border-radius: 0;
-    -fx-background-radius: 0;
-    -fx-label-padding: 0.2em 0 0.2em 2.2em;;
-    -fx-background-size: 2em;
-    -fx-background-repeat: no-repeat;
-    -fx-background-position: left;
-}
+    .leftButton {
+        -fx-padding: 0 0.83em 0 0.83em;
+        -fx-background-color: transparent;
+        -fx-border-color: transparent;
+        -fx-cursor: hand;
+        -fx-text-fill: @text-color;
+        -fx-txt-font-family: "Roboto Light";
+        -fx-border-radius: 0;
+        -fx-background-radius: 0;
+        -fx-label-padding: 0.2em 0 0.2em 2.2em;;
+        -fx-background-size: 2em;
+        -fx-background-repeat: no-repeat;
+        -fx-background-position: left;
+    }
 
-.leftButton:hover {
-    -fx-border-color: transparent;
-}
+    .leftButton:hover {
+        -fx-border-color: transparent;
+    }
 
-.leftButton:selected {
-    -fx-background-color: linear-gradient(#ea6e3c, #f68152);
-    -fx-border-color: transparent;
-    -fx-background-insets: 0, 1, 2;
-    -fx-background-radius: 0;
-    -fx-text-fill: white;
-}
+    .leftButton:selected {
+        -fx-background-color: linear-gradient(#ea6e3c, #f68152);
+        -fx-border-color: transparent;
+        -fx-background-insets: 0, 1, 2;
+        -fx-background-radius: 0;
+        -fx-text-fill: white;
+    }
 
-.searchBar {
-    -fx-border-radius: 0;
-    -fx-background-radius: 0;
-    -fx-background-color: @background-color;
-    -fx-border-color: transparent;
-    -fx-text-fill: @text-color;
-    -fx-focus-color: @focus-color;
-}
+    .searchBar {
+        -fx-border-radius: 0;
+        -fx-background-radius: 0;
+        -fx-background-color: @background-color;
+        -fx-border-color: transparent;
+        -fx-text-fill: @text-color;
+        -fx-focus-color: @focus-color;
+    }
 
-.searchBar:focused {
-    -fx-border-color: transparent;
-    -fx-text-fill: @text-color;
-}
+    .searchBar:focused {
+        -fx-border-color: transparent;
+        -fx-text-fill: @text-color;
+    }
 
-.searchBar:hover {
-    -fx-border-color: @focus-color;
-    -fx-text-fill: @text-color;
-}
+    .searchBar:hover {
+        -fx-border-color: @focus-color;
+        -fx-text-fill: @text-color;
+    }
 
-.searchCleanButton {
-	-fx-background-color: transparent;
-	-fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/edit-clear.png');
+    .searchCleanButton {
+        -fx-background-color: transparent;
+        -fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/edit-clear.png');
+    }
 }
 
 /*******************************************************/


### PR DESCRIPTION
This PR does the following:
- changed `LeftSideBar` and its inheritors to extend `BorderPane` instead of `ScrollPane`
- added a `LeftListWidgetChooser` to all all tabs except the settings
- used a scroll pane for everything that scales with its content (`LeftToggleGroup` for example) **inside** the sidebar, instead of using a scroll pane for the whole sidebar

Some interesting findings:
- when using a `ScrollPane` inside a `BorderPane` the padding from the `BorderPane` gets ignored... I solved this by adding a padding to the scrollpane inside the sidebar via css

Some images:
![grafik](https://cloud.githubusercontent.com/assets/18488086/26255154/0aa158c2-3cb9-11e7-8e9f-15aa6d3dcf73.png)
![grafik](https://cloud.githubusercontent.com/assets/18488086/26255160/0c287108-3cb9-11e7-8970-661e395c3ea1.png)
![grafik](https://cloud.githubusercontent.com/assets/18488086/26255162/0d7f0ea4-3cb9-11e7-9e62-3a0346433ac4.png)
![grafik](https://cloud.githubusercontent.com/assets/18488086/26255164/0fbd7f98-3cb9-11e7-9f4e-649fba7fe8d9.png)
![grafik](https://cloud.githubusercontent.com/assets/18488086/26255170/156099d0-3cb9-11e7-99fe-8ce54710dbb5.png)
![grafik](https://cloud.githubusercontent.com/assets/18488086/26255174/172c0218-3cb9-11e7-93aa-565b17da79fe.png)
![grafik](https://cloud.githubusercontent.com/assets/18488086/26255178/196084b4-3cb9-11e7-880a-db859378ce7f.png)
![grafik](https://cloud.githubusercontent.com/assets/18488086/26255183/1b70ab30-3cb9-11e7-9368-5e3e4c2e5730.png)