### PR TITLE
fixed search clean button in Unity theme

### DIFF
--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
@@ -425,6 +425,7 @@
 
     .searchCleanButton {
         -fx-background-color: transparent;
+        -fx-border-color:transparent;
         -fx-graphic: url('/org/phoenicis/javafx/themes/default/icons/mainwindow/general/edit-clear.png');
     }
 }


### PR DESCRIPTION
Removed ugly border of the clean button in the search box.
![clean button](https://cloud.githubusercontent.com/assets/3973260/26276114/3c9bc610-3d71-11e7-8f7b-fa59af184a09.png)