### PR TITLE
use pseudo class for "selected" state of icons list element

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widgets/lists/icons/IconsListElement.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widgets/lists/icons/IconsListElement.java
@@ -1,5 +1,8 @@
 package org.phoenicis.javafx.views.common.widgets.lists.icons;
 
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.BooleanPropertyBase;
+import javafx.css.PseudoClass;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
@@ -19,6 +22,29 @@ import java.net.URI;
  * @since 15.05.17
  */
 public class IconsListElement<E> extends VBox {
+
+    private static PseudoClass SELECTED_PSEUDO_CLASS = PseudoClass.getPseudoClass("selected");
+
+    BooleanProperty selected = new BooleanPropertyBase(false) {
+        public void invalidated() {
+            pseudoClassStateChanged(SELECTED_PSEUDO_CLASS, get());
+        }
+
+        @Override
+        public Object getBean() {
+            return IconsListElement.this;
+        }
+
+        @Override
+        public String getName() {
+            return "selected";
+        }
+    };
+
+    public void setSelected(boolean selected) {
+        this.selected.set(selected);
+    }
+
     /**
      * The item this element contains
      */

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widgets/lists/icons/IconsListElement.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widgets/lists/icons/IconsListElement.java
@@ -45,6 +45,10 @@ public class IconsListElement<E> extends VBox {
         this.selected.set(selected);
     }
 
+    public boolean isSelected() {
+        return this.selected.get();
+    }
+
     /**
      * The item this element contains
      */

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widgets/lists/icons/IconsListWidget.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/common/widgets/lists/icons/IconsListWidget.java
@@ -27,7 +27,6 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.FlowPane;
 import org.phoenicis.javafx.views.common.MappedList;
 import org.phoenicis.javafx.views.common.widgets.lists.ListWidget;
-import org.phoenicis.javafx.views.common.widgets.lists.ListWidgetEntry;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -113,7 +112,7 @@ public final class IconsListWidget<E> extends ScrollPane implements ListWidget<E
 
     @Override
     public void deselectAll() {
-        this.selectedItems.forEach(element -> element.getStyleClass().remove("selected"));
+        this.selectedItems.forEach(element -> element.setSelected(false));
         this.selectedItems.clear();
     }
 
@@ -121,9 +120,7 @@ public final class IconsListWidget<E> extends ScrollPane implements ListWidget<E
     public void select(E selectedItem) {
         IconsListElement<E> item = this.mappedElements.get(this.items.indexOf(selectedItem));
 
-        if (!item.getStyleClass().contains("selected")) {
-            item.getStyleClass().add("selected");
-        }
+        item.setSelected(true);
 
         this.selectedItems.add(item);
     }

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/breezeDark/main.less
@@ -489,7 +489,7 @@
     -fx-background-color: #284150;
 }
 
-.miniatureListElement.selected {
+.miniatureListElement:selected {
     -fx-background-color: @focus-color;
 }
 

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/dark/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/dark/main.less
@@ -294,6 +294,10 @@
     -fx-background-color: #EFEFEF;
 }
 
+.miniatureListElement:selected {
+  -fx-background-color: #EAEAEA;
+}
+
 .miniatureImage {
     -fx-border-radius: 0.4em;
     -fx-background-radius: 0.4em;

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/default/main.less
@@ -289,7 +289,7 @@
   -fx-background-color: #EFEFEF;
 }
 
-.miniatureListElement.selected {
+.miniatureListElement:selected {
   -fx-background-color: #EAEAEA;
 }
 

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
@@ -535,7 +535,10 @@
 
 .miniatureListElement:hover {
     -fx-background-color: rgba(223, 94, 30, 0.7);
-    -fx-background-opacity: 0.4;
+}
+
+.miniatureListElement:selected {
+    -fx-background-color: rgba(223, 94, 30, 1);
 }
 
 .miniatureImage {


### PR DESCRIPTION
fixes #809

Also, added `selected` state to dark and Unity themes:

![dark](https://cloud.githubusercontent.com/assets/3973260/26283814/0cac1220-3e2f-11e7-8592-5fba9c6c8ec8.png)
![unity](https://cloud.githubusercontent.com/assets/3973260/26283811/fb45bdd8-3e2e-11e7-945a-1ec118fea3f5.png)
