### PR TITLE
Unity theme: use white text for selected tabs and category buttons

### DIFF
--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
@@ -127,8 +127,8 @@
     -fx-border-radius: 0;
 }
 
-.tab-header-area .tab:selected .tab-label {
-    -fx-text-fill: white;
+.tab-header-area .tab:selected .tab-label .text {
+    -fx-fill: white;
 }
 
 .list-view {

--- a/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
+++ b/phoenicis-javafx/src/main/resources/org/phoenicis/javafx/themes/unity/main.less
@@ -385,7 +385,10 @@
         -fx-border-color: transparent;
         -fx-background-insets: 0, 1, 2;
         -fx-background-radius: 0;
-        -fx-text-fill: white;
+
+        .text {
+            -fx-fill: white;
+        }
     }
 
     .searchBar {


### PR DESCRIPTION
fixes #838 

![tab](https://cloud.githubusercontent.com/assets/3973260/26549224/3c50d534-4478-11e7-9238-4edb09601dcb.png)