### PR TITLE
Add a gui dialog for the addition of repositories

### DIFF
--- a/phoenicis-javafx/pom.xml
+++ b/phoenicis-javafx/pom.xml
@@ -176,6 +176,11 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.controlsfx</groupId>
+            <artifactId>controlsfx</artifactId>
+            <version>8.40.12</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/phoenicis-javafx/pom.xml
+++ b/phoenicis-javafx/pom.xml
@@ -175,12 +175,6 @@
             <artifactId>phoenicis-settings</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.controlsfx</groupId>
-            <artifactId>controlsfx</artifactId>
-            <version>8.40.12</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/AddRepositoryDialog.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/AddRepositoryDialog.java
@@ -1,0 +1,207 @@
+package org.phoenicis.javafx.views.mainwindow.settings;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.*;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.stage.DirectoryChooser;
+import org.controlsfx.dialog.Wizard;
+import org.controlsfx.dialog.WizardPane;
+import org.phoenicis.repository.location.ClasspathRepositoryLocation;
+import org.phoenicis.repository.location.GitRepositoryLocation;
+import org.phoenicis.repository.location.LocalRepositoryLocation;
+import org.phoenicis.repository.location.RepositoryLocation;
+import org.phoenicis.repository.repositoryTypes.Repository;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Optional;
+
+import static org.phoenicis.configuration.localisation.Localisation.tr;
+
+/**
+ * A dialog for the addition of a new repository to Phoenicis.
+ * This dialog contains a wizard with two steps:
+ * <ol>
+ *     <li>a selection step, to select the correct repository type</li>
+ *     <li>a details step, to input specific repository type related information</li>
+ * </ol>
+ *
+ * @author marc
+ * @since 12.06.17
+ */
+public class AddRepositoryDialog extends Wizard {
+    /**
+     * A list containing all possible repository types to be added with this dialog
+     */
+    private ObservableList<String> repositoryChoices;
+
+    /**
+     * The wizard repository type selection step
+     */
+    private WizardPane repositoryTypeSelection;
+
+    /**
+     * The choice box containing, which repository type the user wants to add
+     */
+    private ChoiceBox<String> choiceBox;
+
+    /**
+     * The wizard repository details step
+     */
+    private WizardPane repositoryDetailsSelection;
+
+    /**
+     * The result value of this wizard.
+     * This wizard is {@link Optional#empty()} until the user completed the wizard
+     */
+    private Optional<RepositoryLocation<? extends Repository>> resultRepository;
+
+    /**
+     * Constructor
+     */
+    public AddRepositoryDialog() {
+        super();
+
+        this.repositoryChoices = FXCollections.observableArrayList("Local Repository", "Git Repository",
+                "Classpath Repository");
+        this.resultRepository = Optional.empty();
+
+        this.setTitle(tr("Add a new Repository"));
+
+        this.repositoryTypeSelection = new WizardPane();
+
+        this.repositoryDetailsSelection = new WizardPane() {
+            @Override
+            public void onEnteringPage(Wizard wizard) {
+                switch (choiceBox.getSelectionModel().getSelectedItem()) {
+                    case "Local Repository":
+                        populateLocalRepositoryDetailsPage();
+                        break;
+                    case "Git Repository":
+                        populateGitRepositoryDetailsPage();
+                        break;
+                    case "Classpath Repository":
+                        populateClasspathRepositoryDetailsPage();
+                        break;
+                    default:
+                }
+            }
+        };
+
+        this.populateTypePage();
+
+        this.setFlow(new LinearFlow(repositoryTypeSelection, repositoryDetailsSelection));
+    }
+
+    /**
+     * Populates the repository selection step
+     */
+    private void populateTypePage() {
+        choiceBox = new ChoiceBox<>(repositoryChoices);
+        choiceBox.getSelectionModel().selectFirst();
+
+        Label choiceBoxLabel = new Label(tr("Repository type:"));
+        choiceBoxLabel.setLabelFor(choiceBox);
+
+        HBox content = new HBox(choiceBoxLabel, choiceBox);
+        HBox.setHgrow(choiceBox, Priority.ALWAYS);
+
+        repositoryTypeSelection.setHeaderText(tr("Choose the repository type"));
+        repositoryTypeSelection.setContent(content);
+    }
+
+    /**
+     * Populates the repository details step for the local repository
+     */
+    private void populateLocalRepositoryDetailsPage() {
+        TextField pathField = new TextField();
+
+        Button openBrowser = new Button(tr("Open directory chooser"));
+        openBrowser.setOnAction(event -> {
+            DirectoryChooser chooser = new DirectoryChooser();
+
+            File directory = chooser.showDialog(null);
+
+            pathField.setText(directory.toString());
+        });
+
+        HBox content = new HBox(pathField, openBrowser);
+        HBox.setHgrow(pathField, Priority.ALWAYS);
+
+        Button finishButton = (Button) repositoryDetailsSelection.lookupButton(ButtonType.FINISH);
+        finishButton.setOnAction(event -> {
+            resultRepository = Optional.of(new LocalRepositoryLocation(new File(pathField.getText())));
+        });
+
+        repositoryDetailsSelection.setHeaderText(tr("Choose the location of your local repository"));
+        repositoryDetailsSelection.setContent(content);
+    }
+
+    /**
+     * Populates the repository details step for the git repository
+     */
+    private void populateGitRepositoryDetailsPage() {
+        TextField urlField = new TextField();
+        TextField branchField = new TextField("master");
+
+        Label urlLabel = new Label("Git-Url:");
+        urlLabel.setLabelFor(urlField);
+        Label branchLabel = new Label("Branch:");
+        branchLabel.setLabelFor(branchField);
+
+        GridPane grid = new GridPane();
+        grid.add(urlLabel, 0, 0);
+        grid.add(urlField, 1, 0);
+
+        grid.add(branchLabel, 0, 1);
+        grid.add(branchField, 1, 1);
+
+        Button finishButton = (Button) repositoryDetailsSelection.lookupButton(ButtonType.FINISH);
+        finishButton.setOnAction(event -> {
+            try {
+                resultRepository = Optional.of(new GitRepositoryLocation.Builder()
+                        .withGitRepositoryUri(new URL(urlField.getText()).toURI()).build());
+            } catch (MalformedURLException | URISyntaxException e) {
+                e.printStackTrace();
+            }
+        });
+
+        repositoryDetailsSelection.setHeaderText("Choose the location of your git repository");
+        repositoryDetailsSelection.setContent(grid);
+    }
+
+    /**
+     * Populates the repository details step for the classpath repository
+     */
+    private void populateClasspathRepositoryDetailsPage() {
+        TextField classpathField = new TextField();
+
+        Label classpathLabel = new Label(tr("Classpath:"));
+        classpathLabel.setLabelFor(classpathField);
+
+        HBox content = new HBox(classpathLabel, classpathField);
+        HBox.setHgrow(classpathField, Priority.ALWAYS);
+
+        Button finishButton = (Button) repositoryDetailsSelection.lookupButton(ButtonType.FINISH);
+        finishButton.setOnAction(event -> {
+            resultRepository = Optional.of(new ClasspathRepositoryLocation(classpathField.getText()));
+        });
+
+        repositoryDetailsSelection.setHeaderText(tr("Choose the location of your classpath repository"));
+        repositoryDetailsSelection.setContent(content);
+    }
+
+    /**
+     * Returns the resulting {@link RepositoryLocation} of this wizard
+     * @return The resulting {@link RepositoryLocation} of this wizard,
+     * or {@link Optional#empty()}, if the wizard has not been completed
+     */
+    public Optional<RepositoryLocation<? extends Repository>> getResultRepository() {
+        return resultRepository;
+    }
+}

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/RepositoriesPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/RepositoriesPanel.java
@@ -127,9 +127,9 @@ public class RepositoriesPanel extends StackPane {
         this.addButton.setOnAction((ActionEvent event) -> {
             AddRepositoryDialog dialog = new AddRepositoryDialog();
 
-            Optional<ButtonType> successResult = dialog.showAndWait();
+            Optional<RepositoryLocation<? extends Repository>> successResult = dialog.showAndWait();
 
-            dialog.getResultRepository().ifPresent(repositoryLocation -> {
+            successResult.ifPresent(repositoryLocation -> {
                 repositories.add(repositoryLocation);
 
                 this.save();

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/RepositoriesPanel.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/RepositoriesPanel.java
@@ -10,8 +10,8 @@ import javafx.geometry.VPos;
 import javafx.scene.control.*;
 import javafx.scene.layout.*;
 import javafx.scene.text.Text;
-import org.phoenicis.repository.RepositoryManager;
 import org.phoenicis.javafx.views.common.TextWithStyle;
+import org.phoenicis.repository.RepositoryManager;
 import org.phoenicis.repository.location.RepositoryLocation;
 import org.phoenicis.repository.repositoryTypes.Repository;
 import org.phoenicis.settings.SettingsManager;
@@ -56,7 +56,7 @@ public class RepositoriesPanel extends StackPane {
     /**
      * Constructor
      *
-     * @param settingsManager The settings manager
+     * @param settingsManager   The settings manager
      * @param repositoryManager The repository manager
      */
     public RepositoriesPanel(SettingsManager settingsManager, RepositoryManager repositoryManager) {
@@ -125,23 +125,17 @@ public class RepositoriesPanel extends StackPane {
         this.addButton = new Button();
         this.addButton.setText(tr("Add"));
         this.addButton.setOnAction((ActionEvent event) -> {
-            TextInputDialog dialog = new TextInputDialog();
-            dialog.initOwner(getScene().getWindow());
-            dialog.setTitle(tr("Add repository"));
-            dialog.setHeaderText(tr("Add repository"));
-            dialog.setContentText(tr("Please add the new repository:"));
+            AddRepositoryDialog dialog = new AddRepositoryDialog();
 
-            Optional<String> result = dialog.showAndWait();
-            /*
-             * TODO: replace by new GUI dialog (#776 and #857)
-             */
-            //result.ifPresent(newRepository -> {
-            //    repositories.add(0, newRepository);
-            //
-            //    this.save();
-            //
-            //    repositoryManager.addRepositories(0, newRepository);
-            //});
+            Optional<ButtonType> successResult = dialog.showAndWait();
+
+            dialog.getResultRepository().ifPresent(repositoryLocation -> {
+                repositories.add(repositoryLocation);
+
+                this.save();
+
+                repositoryManager.addRepositories(0, repositoryLocation);
+            });
         });
 
         this.removeButton = new Button();

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/repositoryTypes/GitRepository.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/repositoryTypes/GitRepository.java
@@ -74,7 +74,7 @@ public class GitRepository implements Repository {
         RepositoryDTO result = null;
         Git gitRepository = null;
 
-        try {       
+        try {
             /*
              * if the repository folder previously didn't exist, clone the
              * repository now

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/repositoryTypes/MergeableRepository.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/repositoryTypes/MergeableRepository.java
@@ -73,7 +73,8 @@ public abstract class MergeableRepository implements Repository {
                 final CategoryDTO category = entry.getValue();
 
                 if (mergedCategories.containsKey(entry.getKey())) {
-                    mergedCategories.put(entry.getKey(), mergeCategories(mergedCategories.get(entry.getKey()), category));
+                    mergedCategories.put(entry.getKey(),
+                            mergeCategories(mergedCategories.get(entry.getKey()), category));
                 } else {
                     mergedCategories.put(entry.getKey(), category);
                 }

--- a/phoenicis-tools/src/main/java/org/phoenicis/tools/system/terminal/MacOSTerminalOpener.java
+++ b/phoenicis-tools/src/main/java/org/phoenicis/tools/system/terminal/MacOSTerminalOpener.java
@@ -53,8 +53,7 @@ class MacOSTerminalOpener implements TerminalOpener {
                 .append("[ -e \"$HOME/.profile\" ] && rcFile=\"~/.profile\" || rcFile=\"/etc/profile\"\n");
 
         for (Map.Entry<String, String> entry : environmentVariables.entrySet()) {
-            scriptBuilder.append(String.format("export %s=\"%s\"%n", entry.getKey(),
-                    entry.getValue()));
+            scriptBuilder.append(String.format("export %s=\"%s\"%n", entry.getKey(), entry.getValue()));
         }
         return scriptBuilder.append("exec bash -c \"clear;printf '\\e[3J';bash --rcfile $rcFile\"").toString();
     }


### PR DESCRIPTION
This PR fixes #776.
My problem with the taken approach is the used library `controlsfx`.
This library provides a `Wizard` component, which I'm using to divide the repository addition process in two parts:

1. The selection of the repository type (git, classpath, local)
2. The input phase of repository type dependent information (git url, classpath, file path)

This wizard restricts us in some aspects. One such aspect is the used css styles. The only way we can bind a stylesheet to the wizard seems to be to bind it to all the wizard steps. The same is true for the definition of a size for the wizard dialog.
My last and greatest problem is the provided translation from `controlsfx`. This translation has some "minor" bugs, like a misspelling of `Nächster`. In addition the chosen translations may not be the best, like someone wrote in the issue system of `controlsfx`. 

![grafik](https://user-images.githubusercontent.com/18488086/27031359-4858b6a0-4f70-11e7-9d10-af51e4d14231.png)
![grafik](https://user-images.githubusercontent.com/18488086/27031362-4a1f1bfa-4f70-11e7-984b-c06d645b266f.png)
![grafik](https://user-images.githubusercontent.com/18488086/27031363-4bba02ae-4f70-11e7-9a76-0c1a999a515e.png)
![grafik](https://user-images.githubusercontent.com/18488086/27031364-4d68386e-4f70-11e7-80cb-0c0b691d9948.png)

As a short note:
The git branch is currently not used, I've just added it because I want to provide its behavior in my next PR.
