### PR TITLE
Use git branch when cloning a git repository

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/AddRepositoryDialog.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/settings/AddRepositoryDialog.java
@@ -12,6 +12,8 @@ import org.phoenicis.repository.location.GitRepositoryLocation;
 import org.phoenicis.repository.location.LocalRepositoryLocation;
 import org.phoenicis.repository.location.RepositoryLocation;
 import org.phoenicis.repository.repositoryTypes.Repository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -34,6 +36,8 @@ import static org.phoenicis.configuration.localisation.Localisation.tr;
  * @since 12.06.17
  */
 public class AddRepositoryDialog extends Dialog<RepositoryLocation<? extends Repository>> {
+    private final static Logger LOGGER = LoggerFactory.getLogger(AddRepositoryDialog.class);
+
     /**
      * A list containing all possible repository types to be added with this dialog
      */
@@ -156,10 +160,11 @@ public class AddRepositoryDialog extends Dialog<RepositoryLocation<? extends Rep
 
         resultSupplier = () -> {
             try {
-                return Optional.of(new GitRepositoryLocation.Builder()
-                        .withGitRepositoryUri(new URL(urlField.getText()).toURI()).build());
+                return Optional.of(
+                        new GitRepositoryLocation.Builder().withGitRepositoryUri(new URL(urlField.getText()).toURI())
+                                .withBranch(branchField.getText()).build());
             } catch (MalformedURLException | URISyntaxException e) {
-                e.printStackTrace();
+                LOGGER.error(String.format("The given url '%s' is no valid URI or URL", urlField.getText()), e);
                 return Optional.empty();
             }
         };

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/RepositoryConfiguration.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/RepositoryConfiguration.java
@@ -104,9 +104,11 @@ public class RepositoryConfiguration {
         } else {
             try {
                 result.add(new GitRepositoryLocation.Builder()
-                        .withGitRepositoryUri(new URL("https://github.com/PlayOnLinux/Scripts").toURI()).build());
+                        .withGitRepositoryUri(new URL("https://github.com/PlayOnLinux/Scripts").toURI())
+                        .withBranch("master").build());
                 result.add(new GitRepositoryLocation.Builder()
-                        .withGitRepositoryUri(new URL("https://github.com/PlayOnLinux/Oldwares").toURI()).build());
+                        .withGitRepositoryUri(new URL("https://github.com/PlayOnLinux/Oldwares").toURI())
+                        .withBranch("master").build());
                 result.add(new ClasspathRepositoryLocation("/org/phoenicis/repository"));
             } catch (URISyntaxException | MalformedURLException e) {
                 LOGGER.error("Couldn't create default repository location list", e);

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/location/GitRepositoryLocation.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/location/GitRepositoryLocation.java
@@ -26,6 +26,11 @@ public class GitRepositoryLocation extends RepositoryLocation<GitRepository> {
     private final URI gitRepositoryUri;
 
     /**
+     * The branch in which the repository is located
+     */
+    private final String branch;
+
+    /**
      * Constructor
      *
      * @param builder The builder object, containing the values for this {@link GitRepositoryLocation}
@@ -34,16 +39,21 @@ public class GitRepositoryLocation extends RepositoryLocation<GitRepository> {
         super("git");
 
         this.gitRepositoryUri = builder.gitRepositoryUri;
+        this.branch = builder.branch;
     }
 
     @Override
     public GitRepository createRepository(String cacheDirectoryPath, LocalRepository.Factory localRepositoryFactory,
             ClasspathRepository.Factory classPathRepositoryFactory, FileUtilities fileUtilities) {
-        return new GitRepository(gitRepositoryUri, cacheDirectoryPath, localRepositoryFactory, fileUtilities);
+        return new GitRepository(gitRepositoryUri, branch, cacheDirectoryPath, localRepositoryFactory, fileUtilities);
     }
 
     public URI getGitRepositoryUri() {
         return gitRepositoryUri;
+    }
+
+    public String getBranch() {
+        return branch;
     }
 
     @Override
@@ -58,27 +68,30 @@ public class GitRepositoryLocation extends RepositoryLocation<GitRepository> {
 
         GitRepositoryLocation that = (GitRepositoryLocation) o;
 
-        return new EqualsBuilder().append(gitRepositoryUri, that.gitRepositoryUri).isEquals();
+        return new EqualsBuilder().append(gitRepositoryUri, that.gitRepositoryUri).append(branch, that.branch)
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(gitRepositoryUri).toHashCode();
+        return new HashCodeBuilder().append(gitRepositoryUri).append(branch).toHashCode();
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).append(gitRepositoryUri).toString();
+        return new ToStringBuilder(this).append(gitRepositoryUri).append(branch).toString();
     }
 
     @Override
     public String toDisplayString() {
-        return String.format("git+%s", gitRepositoryUri.toString());
+        return String.format("git+%s:%s", gitRepositoryUri.toString(), branch);
     }
 
     @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
     public static class Builder {
         private URI gitRepositoryUri;
+
+        private String branch;
 
         public Builder() {
             // Default constructor
@@ -86,10 +99,16 @@ public class GitRepositoryLocation extends RepositoryLocation<GitRepository> {
 
         public Builder(GitRepositoryLocation location) {
             this.withGitRepositoryUri(location.getGitRepositoryUri());
+            this.withBranch(location.getBranch());
         }
 
         public Builder withGitRepositoryUri(URI gitRepositoryUri) {
             this.gitRepositoryUri = gitRepositoryUri;
+            return this;
+        }
+
+        public Builder withBranch(String branch) {
+            this.branch = branch;
             return this;
         }
 


### PR DESCRIPTION
This PR fixes #857.
To support the creation of multiple git repositories with the same url and different branches, the branch name is now also included in the calculation of the of local repository folder name.
In addition this PR does some small cleanup on the variable names in `GitRepository`.