### PR TITLE
restrict DTO IDs to letters and numbers

### DIFF
--- a/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutCategoryDTO.java
+++ b/phoenicis-library/src/main/java/org/phoenicis/library/dto/ShortcutCategoryDTO.java
@@ -24,6 +24,8 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.phoenicis.configuration.localisation.Translatable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -38,6 +40,8 @@ import static org.phoenicis.configuration.localisation.Localisation.tr;
  */
 @JsonDeserialize(builder = ShortcutCategoryDTO.Builder.class)
 public class ShortcutCategoryDTO implements Translatable<ShortcutCategoryDTO> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShortcutCategoryDTO.class);
+
     private final String id;
     private final String name;
     private final String description;
@@ -45,7 +49,18 @@ public class ShortcutCategoryDTO implements Translatable<ShortcutCategoryDTO> {
     private URI icon;
 
     private ShortcutCategoryDTO(Builder builder) {
-        this.id = builder.id;
+        if (builder.id != null) {
+            if (builder.id.matches("^[a-zA-Z0-9]+$")) {
+                this.id = builder.id;
+            } else {
+                LOGGER.warn(String.format("Shortcut category ID (%s) contains invalid characters, will remove them.",
+                        builder.id));
+                this.id = builder.id.replaceAll("[^a-zA-Z0-9]", "");
+            }
+        } else {
+            this.id = null;
+        }
+
         this.name = builder.name == null ? builder.id : builder.name;
         this.description = builder.description;
         this.shortcuts = Collections.unmodifiableList(builder.shortcuts);

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/ApplicationDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/ApplicationDTO.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.phoenicis.configuration.localisation.Translatable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.*;
@@ -35,6 +37,8 @@ import static org.phoenicis.configuration.localisation.Localisation.tr;
  */
 @JsonDeserialize(builder = ApplicationDTO.Builder.class)
 public class ApplicationDTO implements Translatable<ApplicationDTO> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationDTO.class);
+
     private final String id;
     private final String name;
     private final String description;
@@ -44,7 +48,18 @@ public class ApplicationDTO implements Translatable<ApplicationDTO> {
     private final List<ResourceDTO> resources;
 
     private ApplicationDTO(Builder builder) {
-        this.id = builder.id;
+        if (builder.id != null) {
+            if (builder.id.matches("^[a-zA-Z0-9]+$")) {
+                this.id = builder.id;
+            } else {
+                LOGGER.warn(String.format("Application ID (%s) contains invalid characters, will remove them.",
+                        builder.id));
+                this.id = builder.id.replaceAll("[^a-zA-Z0-9]", "");
+            }
+        } else {
+            this.id = null;
+        }
+
         this.name = builder.name == null ? builder.id : builder.name;
         this.description = builder.description;
         this.icon = builder.icon;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/ApplicationDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/ApplicationDTO.java
@@ -198,6 +198,10 @@ public class ApplicationDTO implements Translatable<ApplicationDTO> {
             return new ApplicationDTO(this);
         }
 
+        public String getId() {
+            return id;
+        }
+
         public String getName() {
             return name;
         }

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/CategoryDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/CategoryDTO.java
@@ -24,6 +24,8 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.phoenicis.configuration.localisation.Translatable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -38,6 +40,8 @@ import static org.phoenicis.configuration.localisation.Localisation.tr;
  */
 @JsonDeserialize(builder = CategoryDTO.Builder.class)
 public class CategoryDTO implements Translatable<CategoryDTO> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CategoryDTO.class);
+
     private final CategoryType type;
     private final String id;
     private final String name;
@@ -46,7 +50,19 @@ public class CategoryDTO implements Translatable<CategoryDTO> {
 
     private CategoryDTO(Builder builder) {
         this.type = builder.type;
-        this.id = builder.id;
+
+        if (builder.id != null) {
+            if (builder.id.matches("^[a-zA-Z0-9]+$")) {
+                this.id = builder.id;
+            } else {
+                LOGGER.warn(
+                        String.format("Category ID (%s) contains invalid characters, will remove them.", builder.id));
+                this.id = builder.id.replaceAll("[^a-zA-Z0-9]", "");
+            }
+        } else {
+            this.id = null;
+        }
+
         this.name = builder.name == null ? builder.id : builder.name;
         this.applications = Collections.unmodifiableList(builder.applications);
         this.icon = builder.icon;

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/CategoryDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/CategoryDTO.java
@@ -157,6 +157,14 @@ public class CategoryDTO implements Translatable<CategoryDTO> {
         public CategoryDTO build() {
             return new CategoryDTO(this);
         }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
     }
 
     @Override

--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/repositoryTypes/LocalRepository.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/repositoryTypes/LocalRepository.java
@@ -101,8 +101,15 @@ public class LocalRepository implements Repository {
 
                 if (categoryJson.exists()) {
                     final CategoryDTO.Builder categoryDTOBuilder = new CategoryDTO.Builder(
-                            unSerializeCategory(categoryJson)).withId(categoryDirectory.getName())
-                                    .withApplications(fetchApplications(categoryDirectory));
+                            unSerializeCategory(categoryJson)).withApplications(fetchApplications(categoryDirectory));
+
+                    if (StringUtils.isBlank(categoryDTOBuilder.getId())) {
+                        if (!StringUtils.isBlank(categoryDTOBuilder.getName())) {
+                            categoryDTOBuilder.withId(categoryDTOBuilder.getName().replaceAll("[^a-zA-Z0-9]", ""));
+                        } else {
+                            categoryDTOBuilder.withId(categoryDirectory.getName().replaceAll("[^a-zA-Z0-9]", ""));
+                        }
+                    }
 
                     final File categoryIconFile = new File(categoryDirectory, CATEGORY_ICON_NAME);
                     if (categoryIconFile.exists()) {
@@ -133,8 +140,12 @@ public class LocalRepository implements Repository {
                 final ApplicationDTO.Builder applicationDTOBuilder = new ApplicationDTO.Builder(
                         unSerializeApplication(applicationJson));
 
-                if (StringUtils.isBlank(applicationDTOBuilder.getName())) {
-                    applicationDTOBuilder.withId(applicationDirectory.getName());
+                if (StringUtils.isBlank(applicationDTOBuilder.getId())) {
+                    if (!StringUtils.isBlank(applicationDTOBuilder.getName())) {
+                        applicationDTOBuilder.withId(applicationDTOBuilder.getName().replaceAll("[^a-zA-Z0-9]", ""));
+                    } else {
+                        applicationDTOBuilder.withId(applicationDirectory.getName().replaceAll("[^a-zA-Z0-9]", ""));
+                    }
                 }
 
                 final File miniaturesDirectory = new File(applicationDirectory, "miniatures");

--- a/phoenicis-repository/src/test/java/org/phoenicis/repository/repositoryTypes/TeeRepositoryTest.java
+++ b/phoenicis-repository/src/test/java/org/phoenicis/repository/repositoryTypes/TeeRepositoryTest.java
@@ -84,7 +84,7 @@ public class TeeRepositoryTest {
                 new CategoryDTO.Builder().withId("Category 5").build())).build();
 
         final Repository teeSource = new TeeRepository(leftSource, rightSource);
-        assertEquals(3, teeSource.getCategory(Collections.singletonList("Category 2")).getApplications().size());
+        assertEquals(3, teeSource.getCategory(Collections.singletonList("Category2")).getApplications().size());
     }
 
 }


### PR DESCRIPTION
To avoid problems with IDs such as `arcade games` which would create the invalid button ID string `#arcade gamesButton` (would be interpreted as a tag with the ID `arcade`, which contains another element `gamesButton`).