### PR TITLE
fixed missing translations

### DIFF
--- a/phoenicis-configuration/src/main/java/org/phoenicis/configuration/localisation/Localisation.java
+++ b/phoenicis-configuration/src/main/java/org/phoenicis/configuration/localisation/Localisation.java
@@ -55,7 +55,8 @@ public final class Localisation {
      *
      * @param resourceBundle Resource bundle
      */
-    public static void setAdditionalTranslations(ResourceBundle resourceBundle) {
+    public static void setAdditionalTranslations(PropertiesResourceBundle resourceBundle) {
+        resourceBundle.setParent(getI18n().getResources());
         getI18n().setResources(resourceBundle);
     }
 

--- a/phoenicis-configuration/src/main/java/org/phoenicis/configuration/localisation/PropertiesResourceBundle.java
+++ b/phoenicis-configuration/src/main/java/org/phoenicis/configuration/localisation/PropertiesResourceBundle.java
@@ -21,4 +21,9 @@ public class PropertiesResourceBundle extends ResourceBundle {
     public Enumeration<String> getKeys() {
         return this.properties != null ? (Enumeration<String>) this.properties.propertyNames() : this.parent.getKeys();
     }
+
+    @Override
+    public void setParent(ResourceBundle parent) {
+        this.parent = parent;
+    }
 }


### PR DESCRIPTION
Before, calling `setAdditionalTranslations` replaced the `ResourceBundle` for the translation. Therefore, the script translations overwrote the software translations. This worked most of the time because the GUI had been translated already. However, any string of the software which was created afterwards did not get translated (e.g. "Installers" in `AppPanel`).