### PR TITLE
fixed default window width

### DIFF
--- a/phoenicis-configuration/src/main/resources/Linux.properties
+++ b/phoenicis-configuration/src/main/resources/Linux.properties
@@ -24,7 +24,7 @@ application.theme                           =           default
 application.scale                           =           12
 application.viewsource                      =           false
 application.windowHeight                    =           600
-application.windowWidth                     =           800
+application.windowWidth                     =           840
 application.windowMaximized                 =           false
 
 application.user.root                       =           ${user.home}/.Phoenicis

--- a/phoenicis-configuration/src/main/resources/Mac OS X.properties
+++ b/phoenicis-configuration/src/main/resources/Mac OS X.properties
@@ -24,7 +24,7 @@ application.theme                           =           default
 application.scale                           =           12
 application.viewsource                      =           false
 application.windowHeight                    =           600
-application.windowWidth                     =           800
+application.windowWidth                     =           840
 application.windowMaximized                 =           false
 
 application.user.root                       =           ${user.home}/Library/Phoenicis


### PR DESCRIPTION
fixes #932 

Although we will never be able to perfectly adjust the width of the application window (e.g. due to different width of the sidebar because of translation), this PR should improve the appearance with default settings in the majority of cases.

![default width](https://user-images.githubusercontent.com/3973260/27760294-33e8dfb4-5e44-11e7-8c9c-31110a7ce024.png)