### PR TITLE
use default miniature if "main.png" does not exist

### DIFF
--- a/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/ApplicationDTO.java
+++ b/phoenicis-repository/src/main/java/org/phoenicis/repository/dto/ApplicationDTO.java
@@ -105,23 +105,13 @@ public class ApplicationDTO {
     /**
      * Returns the main miniature belonging to this {@link ApplicationDTO}.
      * The main miniature is the miniature with the file name <code>main.png</code>.
-     * If no such miniature exists the first miniature of this {@link ApplicationDTO} is returned.
      * If this {@link ApplicationDTO} contains no miniatures {@link Optional#empty()} is returned.
      *
      * @return An optional with the found URI, or {@link Optional#empty()} if no miniature exists
      */
     @JsonIgnore
     public Optional<URI> getMainMiniature() {
-        Optional<URI> result = this.miniatures.stream().filter(uri -> uri.getPath().endsWith("main.png")).findFirst();
-
-        /*
-         * Fallback in case no main miniature has been selected but the list contains at least one other miniature
-         */
-        if (!result.isPresent()) {
-            result = this.miniatures.stream().findFirst();
-        }
-
-        return result;
+        return this.miniatures.stream().filter(uri -> uri.getPath().endsWith("main.png")).findFirst();
     }
 
     @Override


### PR DESCRIPTION
We do not want e.g. a screenshot to show up in the miniature view if there is no main miniature.

fixes #859