### PR TITLE
use engine category icon from repository as fallback

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/controller/engines/EnginesController.java
@@ -21,7 +21,6 @@ package org.phoenicis.javafx.controller.engines;
 import javafx.application.Platform;
 import jdk.nashorn.api.scripting.ScriptObjectMirror;
 import org.phoenicis.engines.EnginesSource;
-import org.phoenicis.engines.dto.EngineCategoryDTO;
 import org.phoenicis.engines.dto.EngineDTO;
 import org.phoenicis.javafx.controller.apps.AppsController;
 import org.phoenicis.javafx.views.common.ConfirmMessage;
@@ -94,8 +93,9 @@ public class EnginesController {
                     categoryDTOS = typeDTO.getCategories();
                 }
             }
+            setDefaultEngineIcons(categoryDTOS);
             enginesSource.fetchAvailableEngines(categoryDTOS,
-                    versions -> Platform.runLater(() -> populateView(versions)));
+                    versions -> Platform.runLater(() -> this.viewEngines.populate(versions)));
         });
     }
 
@@ -123,15 +123,10 @@ public class EnginesController {
                 }, errorCallback), errorCallback);
     }
 
-    private void populateView(List<EngineCategoryDTO> engineCategoryDTOS) {
-        setDefaultEngineIcons(engineCategoryDTOS);
-        this.viewEngines.populate(engineCategoryDTOS);
-    }
-
-    private void setDefaultEngineIcons(List<EngineCategoryDTO> engineCategoryDTOS) {
+    private void setDefaultEngineIcons(List<CategoryDTO> categoryDTOS) {
         try {
             StringBuilder cssBuilder = new StringBuilder();
-            for (EngineCategoryDTO category : engineCategoryDTOS) {
+            for (CategoryDTO category : categoryDTOS) {
                 cssBuilder.append("#" + category.getName().toLowerCase() + "Button{\n");
                 URI categoryIcon = category.getIcon();
                 if (categoryIcon == null) {


### PR DESCRIPTION
If no icon for the engine category is available in the theme, the "icon.png" from the repository is used.

fixes #792 

For the screenshot below, I removed `#wineButton` from the theme and added the `icon.png` from "Games" to "Engines/Wine".
![fallback](https://user-images.githubusercontent.com/3973260/28744040-f32721f4-7458-11e7-8f2b-aafb6377327e.png)