### PR TITLE
application filter: handle incomplete ApplicationDTO

### DIFF
--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationFilter.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationFilter.java
@@ -4,6 +4,7 @@ import javafx.beans.property.*;
 import org.phoenicis.repository.dto.ApplicationDTO;
 import org.phoenicis.repository.dto.CategoryDTO;
 import org.phoenicis.repository.dto.ScriptDTO;
+import org.springframework.util.CollectionUtils;
 
 import java.util.Optional;
 import java.util.function.BiPredicate;
@@ -150,8 +151,7 @@ public class ApplicationFilter {
          */
         if (!containTestingApplications.getValue()) {
             result &= application.getScripts().stream()
-                    .anyMatch(script -> script.getTestingOperatingSystems() == null
-                            || script.getTestingOperatingSystems().isEmpty());
+                    .anyMatch(script -> CollectionUtils.isEmpty(script.getTestingOperatingSystems()));
         }
 
         return result && filterTextMatcher.test(filterText.getValue(), application);
@@ -184,7 +184,7 @@ public class ApplicationFilter {
          * If "Testing" is not selected, don't show games that are currently in a testing stage
          */
         if (!containTestingApplications.getValue()) {
-            result &= script.getTestingOperatingSystems() == null || script.getTestingOperatingSystems().isEmpty();
+            result &= CollectionUtils.isEmpty(script.getTestingOperatingSystems());
         }
 
         return result;

--- a/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationFilter.java
+++ b/phoenicis-javafx/src/main/java/org/phoenicis/javafx/views/mainwindow/apps/ApplicationFilter.java
@@ -132,25 +132,26 @@ public class ApplicationFilter {
         }
 
         /*
-         * If "commercial" is not selected don't show commercial games
+         * If "commercial" is not selected, don't show commercial games
          */
         if (!containCommercialApplications.getValue()) {
             result &= application.getScripts().stream().anyMatch(script -> script.isFree());
         }
 
         /*
-         * If "Requires patch" is selected show show games that require a patch to run (e.g. no CD)
+         * If "Requires patch" is selected, show games that require a patch to run (e.g. no CD)
          */
         if (containRequiresPatchApplications.getValue()) {
             result &= application.getScripts().stream().anyMatch(script -> !script.isRequiresPatch());
         }
 
         /*
-         * If "Testing" is not selected don't show games that are currently in a testing stage
+         * If "Testing" is not selected, don't show games that are currently in a testing stage
          */
         if (!containTestingApplications.getValue()) {
             result &= application.getScripts().stream()
-                    .anyMatch(script -> script.getTestingOperatingSystems().isEmpty());
+                    .anyMatch(script -> script.getTestingOperatingSystems() == null
+                            || script.getTestingOperatingSystems().isEmpty());
         }
 
         return result && filterTextMatcher.test(filterText.getValue(), application);
@@ -166,24 +167,24 @@ public class ApplicationFilter {
         boolean result = true;
 
         /*
-         * If "commercial" is not selected don't show commercial games
+         * If "commercial" is not selected, don't show commercial games
          */
         if (!containCommercialApplications.getValue()) {
             result &= script.isFree();
         }
 
         /*
-         * If "Requires patch" is selected show show games that require a patch to run (e.g. no CD)
+         * If "Requires patch" is selected, show show games that require a patch to run (e.g. no CD)
          */
         if (containRequiresPatchApplications.getValue()) {
             result &= !script.isRequiresPatch();
         }
 
         /*
-         * If "Testing" is not selected don't show games that are currently in a testing stage
+         * If "Testing" is not selected, don't show games that are currently in a testing stage
          */
         if (!containTestingApplications.getValue()) {
-            result &= script.getTestingOperatingSystems().isEmpty();
+            result &= script.getTestingOperatingSystems() == null || script.getTestingOperatingSystems().isEmpty();
         }
 
         return result;


### PR DESCRIPTION
The ApplicationFilter can now handle ApplicationDTO containing null values. This can happen e.g. if the application.json could not be read or is incomplete. Before, Phoenicis crashed with NullPointerException.